### PR TITLE
Use Write::write_fmt instead of to_string in benches.

### DIFF
--- a/benches/ftoa.rs
+++ b/benches/ftoa.rs
@@ -33,8 +33,15 @@ fn ftoa_f32_dtoa(bench: &mut Bencher) {
     })})
 }
 
-fn ftoa_f32_to_string(bench: &mut Bencher) {
-    bench.iter(|| { F32_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn ftoa_f32_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = Vec::with_capacity(256);
+    bench.iter(|| {
+        F32_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // F64
@@ -59,12 +66,19 @@ fn ftoa_f64_dtoa(bench: &mut Bencher) {
     })})
 }
 
-fn ftoa_f64_to_string(bench: &mut Bencher) {
-    bench.iter(|| { F64_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn ftoa_f64_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = Vec::with_capacity(256);
+    bench.iter(|| {
+        F64_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // MAIN
 
-benchmark_group!(f32_benches, ftoa_f32_lexical, ftoa_f32_dtoa, ftoa_f32_to_string);
-benchmark_group!(f64_benches, ftoa_f64_lexical, ftoa_f64_dtoa, ftoa_f64_to_string);
+benchmark_group!(f32_benches, ftoa_f32_lexical, ftoa_f32_dtoa, ftoa_f32_std);
+benchmark_group!(f64_benches, ftoa_f64_lexical, ftoa_f64_dtoa, ftoa_f64_std);
 benchmark_main!(f32_benches, f64_benches);

--- a/benches/itoa.rs
+++ b/benches/itoa.rs
@@ -25,8 +25,15 @@ fn itoa_u8_itoa(bench: &mut Bencher) {
     })})
 }
 
-fn itoa_u8_to_string(bench: &mut Bencher) {
-    bench.iter(|| { U8_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn itoa_u8_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = vec![b'0'; 256];
+    bench.iter(|| {
+        U8_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // I8
@@ -47,8 +54,15 @@ fn itoa_i8_itoa(bench: &mut Bencher) {
     })})
 }
 
-fn itoa_i8_to_string(bench: &mut Bencher) {
-    bench.iter(|| { I8_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn itoa_i8_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = vec![b'0'; 256];
+    bench.iter(|| {
+        I8_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // U16
@@ -69,8 +83,15 @@ fn itoa_u16_itoa(bench: &mut Bencher) {
     })})
 }
 
-fn itoa_u16_to_string(bench: &mut Bencher) {
-    bench.iter(|| { U16_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn itoa_u16_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = vec![b'0'; 256];
+    bench.iter(|| {
+        U16_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // I16
@@ -91,8 +112,15 @@ fn itoa_i16_itoa(bench: &mut Bencher) {
     })})
 }
 
-fn itoa_i16_to_string(bench: &mut Bencher) {
-    bench.iter(|| { I16_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn itoa_i16_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = vec![b'0'; 256];
+    bench.iter(|| {
+        I16_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // U32
@@ -113,8 +141,15 @@ fn itoa_u32_itoa(bench: &mut Bencher) {
     })})
 }
 
-fn itoa_u32_to_string(bench: &mut Bencher) {
-    bench.iter(|| { U32_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn itoa_u32_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = vec![b'0'; 256];
+    bench.iter(|| {
+        U32_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // I32
@@ -135,8 +170,15 @@ fn itoa_i32_itoa(bench: &mut Bencher) {
     })})
 }
 
-fn itoa_i32_to_string(bench: &mut Bencher) {
-    bench.iter(|| { I32_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn itoa_i32_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = vec![b'0'; 256];
+    bench.iter(|| {
+        I32_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // U64
@@ -157,8 +199,15 @@ fn itoa_u64_itoa(bench: &mut Bencher) {
     })})
 }
 
-fn itoa_u64_to_string(bench: &mut Bencher) {
-    bench.iter(|| { U64_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn itoa_u64_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = vec![b'0'; 256];
+    bench.iter(|| {
+        U64_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // I64
@@ -179,18 +228,25 @@ fn itoa_i64_itoa(bench: &mut Bencher) {
     })})
 }
 
-fn itoa_i64_to_string(bench: &mut Bencher) {
-    bench.iter(|| { I64_DATA.iter().for_each(|x| { black_box(x.to_string()); } ) })
+fn itoa_i64_std(bench: &mut Bencher) {
+    use std::io::Write;
+    let mut buffer = vec![b'0'; 256];
+    bench.iter(|| {
+        I64_DATA.iter().for_each(|x| {
+            black_box(buffer.write_fmt(format_args!("{}", x)).unwrap());
+            unsafe { buffer.set_len(0); } // Way faster than Vec::clear().
+        })
+    })
 }
 
 // MAIN
 
-benchmark_group!(u8_benches, itoa_u8_lexical, itoa_u8_itoa, itoa_u8_to_string);
-benchmark_group!(u16_benches, itoa_u16_lexical, itoa_u16_itoa, itoa_u16_to_string);
-benchmark_group!(u32_benches, itoa_u32_lexical, itoa_u32_itoa, itoa_u32_to_string);
-benchmark_group!(u64_benches, itoa_u64_lexical, itoa_u64_itoa, itoa_u64_to_string);
-benchmark_group!(i8_benches, itoa_i8_lexical, itoa_i8_itoa, itoa_i8_to_string);
-benchmark_group!(i16_benches, itoa_i16_lexical, itoa_i16_itoa, itoa_i16_to_string);
-benchmark_group!(i32_benches, itoa_i32_lexical, itoa_i32_itoa, itoa_i32_to_string);
-benchmark_group!(i64_benches, itoa_i64_lexical, itoa_i64_itoa, itoa_i64_to_string);
+benchmark_group!(u8_benches, itoa_u8_lexical, itoa_u8_itoa, itoa_u8_std);
+benchmark_group!(u16_benches, itoa_u16_lexical, itoa_u16_itoa, itoa_u16_std);
+benchmark_group!(u32_benches, itoa_u32_lexical, itoa_u32_itoa, itoa_u32_std);
+benchmark_group!(u64_benches, itoa_u64_lexical, itoa_u64_itoa, itoa_u64_std);
+benchmark_group!(i8_benches, itoa_i8_lexical, itoa_i8_itoa, itoa_i8_std);
+benchmark_group!(i16_benches, itoa_i16_lexical, itoa_i16_itoa, itoa_i16_std);
+benchmark_group!(i32_benches, itoa_i32_lexical, itoa_i32_itoa, itoa_i32_std);
+benchmark_group!(i64_benches, itoa_i64_lexical, itoa_i64_itoa, itoa_i64_std);
 benchmark_main!(u8_benches, u16_benches, u32_benches, u64_benches, i8_benches, i16_benches, i32_benches, i64_benches);


### PR DESCRIPTION
to_string allocates for each execution, skewing the results. While `lexical` uses a stack buffer.

Before:

```
test ftoa_f32_to_string ... bench:   2,385,195 ns/iter (+/- 53,405)
test ftoa_f64_to_string ... bench:   4,117,150 ns/iter (+/- 4,770)

test itoa_i16_to_string ... bench:     636,069 ns/iter (+/- 2,162)
test itoa_i32_to_string ... bench:     667,573 ns/iter (+/- 2,610)
test itoa_i64_to_string ... bench:     681,796 ns/iter (+/- 3,621)
test itoa_i8_to_string  ... bench:     617,019 ns/iter (+/- 1,359)
test itoa_u16_to_string ... bench:     472,235 ns/iter (+/- 488)
test itoa_u32_to_string ... bench:     501,989 ns/iter (+/- 613)
test itoa_u64_to_string ... bench:     574,271 ns/iter (+/- 786)
test itoa_u8_to_string  ... bench:     472,449 ns/iter (+/- 1,392)
```


After:

```
test ftoa_f32_std     ... bench:   1,645,791 ns/iter (+/- 3,662)
test ftoa_f64_std     ... bench:   2,062,854 ns/iter (+/- 6,309

test itoa_i16_std     ... bench:     440,050 ns/iter (+/- 1,208)
test itoa_i32_std     ... bench:     471,447 ns/iter (+/- 1,532)
test itoa_i64_std     ... bench:     490,417 ns/iter (+/- 2,278)
test itoa_i8_std      ... bench:     426,684 ns/iter (+/- 1,236)
test itoa_u16_std     ... bench:     359,605 ns/iter (+/- 3,592)
test itoa_u32_std     ... bench:     383,459 ns/iter (+/- 2,726)
test itoa_u64_std     ... bench:     454,350 ns/iter (+/- 1,934)
test itoa_u8_std      ... bench:     375,175 ns/iter (+/- 2,524)
```