### PR TITLE
Bump dependencies

### DIFF
--- a/lexical-core/Cargo.toml
+++ b/lexical-core/Cargo.toml
@@ -22,18 +22,18 @@ travis-ci = { repository = "Alexhuszagh/rust-lexical" }
 
 [dependencies]
 cfg-if = "0.1"
-static_assertions = "0.2.5"
+static_assertions = "0.3.3"
 # Use stack-vector for the correct parser.
 stackvector = { version = "^1.0.5", optional = true }
 # Optimized Grisu3 implementation, a well-tested, correct algorithm.
 dtoa = { version = "0.4", optional = true }
 # Optimized Ryu implementation, the fastest correct algorithm.
-ryu = { version = "^0.2.7", optional = true }
+ryu = { version = "^1.0", optional = true }
 
 [dev-dependencies]
 approx = "0.3.0"
-quickcheck = "0.7"
-proptest = "0.8.7"
+quickcheck = "0.8.5"
+proptest = "0.9.4"
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/lexical-core/src/ftoa/ryu.rs
+++ b/lexical-core/src/ftoa/ryu.rs
@@ -14,7 +14,7 @@ pub(crate) fn float_decimal<'a>(f: f32, bytes: &'a mut [u8])
     -> usize
 {
     unsafe {
-        raw::pretty_f2s_buffered_n(f, bytes.as_mut_ptr())
+        raw::format32(f, bytes.as_mut_ptr())
     }
 }
 
@@ -29,6 +29,6 @@ pub(crate) fn double_decimal<'a>(d: f64, bytes: &'a mut [u8])
     -> usize
 {
     unsafe {
-        raw::pretty_d2s_buffered_n(d, bytes.as_mut_ptr())
+        raw::format64(d, bytes.as_mut_ptr())
     }
 }


### PR DESCRIPTION
This bumps `ryu`, `static_assertions`, `quicktest`, and `proptest` to their latest versions. `ryu` is probably the most important of these as it's now reached 1.0, and is also used elsewhere in the ecosystem.