### PR TITLE
Fix proptest tests

### DIFF
--- a/lexical-core/src/atof/api.rs
+++ b/lexical-core/src/atof/api.rs
@@ -404,73 +404,109 @@ mod tests {
         #[test]
         fn f32_invalid_proptest(i in r"[+-]?[0-9]{2}\D?\.\D?[0-9]{2}\D?e[+-]?[0-9]+\D") {
             let res = try_atof32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
         }
 
         #[test]
         fn f32_double_sign_proptest(i in r"[+-]{2}[0-9]{2}\.[0-9]{2}e[+-]?[0-9]+") {
             let res = try_atof32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0 || res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0 || res.error.index == 1);
         }
 
         #[test]
         fn f32_sign_or_dot_only_proptest(i in r"[+-]?\.?") {
             let res = try_atof32_slice(i.as_bytes());
             if i.is_empty() {
-                assert_eq!(res.error.code, ErrorCode::Empty);
+                prop_assert_eq!(res.error.code, ErrorCode::Empty);
             } else {
-                assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+                prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
             }
-            assert!(res.error.index == 0 || res.error.index == 1);
+            prop_assert!(res.error.index == 0 || res.error.index == 1);
         }
 
         #[test]
         fn f32_double_exponent_sign_proptest(i in r"[+-]?[0-9]{2}\.[0-9]{2}e[+-]{2}[0-9]+") {
             let res = try_atof32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
         }
 
         #[test]
         fn f32_missing_exponent_proptest(i in r"[+-]?[0-9]{2}\.[0-9]{2}e[+-]?") {
             let res = try_atof32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+        }
+
+        #[test]
+        fn f32_roundtrip_display_proptest(i in f32::MIN..f32::MAX) {
+            let input: String = format!("{}", i);
+            prop_assert_eq!(i, atof32_slice(input.as_bytes()));
+        }
+
+        #[test]
+        fn f32_roundtrip_debug_proptest(i in f32::MIN..f32::MAX) {
+            let input: String = format!("{:?}", i);
+            prop_assert_eq!(i, atof32_slice(input.as_bytes()));
+        }
+
+        #[test]
+        fn f32_roundtrip_scientific_proptest(i in f32::MIN..f32::MAX) {
+            let input: String = format!("{:e}", i);
+            prop_assert_eq!(i, atof32_slice(input.as_bytes()));
         }
 
         #[test]
         fn f64_invalid_proptest(i in r"[+-]?[0-9]{2}\D?\.\D?[0-9]{2}\D?e[+-]?[0-9]+\D") {
             let res = try_atof64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
         }
 
         #[test]
         fn f64_double_sign_proptest(i in r"[+-]{2}[0-9]{2}\.[0-9]{2}e[+-]?[0-9]+") {
             let res = try_atof64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0 || res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0 || res.error.index == 1);
         }
 
         #[test]
         fn f64_sign_or_dot_only_proptest(i in r"[+-]?\.?") {
             let res = try_atof64_slice(i.as_bytes());
             if i.is_empty() {
-                assert_eq!(res.error.code, ErrorCode::Empty);
+                prop_assert_eq!(res.error.code, ErrorCode::Empty);
             } else {
-                assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+                prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
             }
-            assert!(res.error.index == 0 || res.error.index == 1);
+            prop_assert!(res.error.index == 0 || res.error.index == 1);
         }
 
         #[test]
         fn f64_double_exponent_sign_proptest(i in r"[+-]?[0-9]{2}\.[0-9]{2}e[+-]{2}[0-9]+") {
             let res = try_atof64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
         }
 
         #[test]
         fn f64_missing_exponent_proptest(i in r"[+-]?[0-9]{2}\.[0-9]{2}e[+-]?") {
             let res = try_atof64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+        }
+
+        #[test]
+        fn f64_roundtrip_display_proptest(i in f64::MIN..f64::MAX) {
+            let input: String = format!("{}", i);
+            prop_assert_eq!(i, atof64_slice(input.as_bytes()));
+        }
+
+        #[test]
+        fn f64_roundtrip_debug_proptest(i in f64::MIN..f64::MAX) {
+            let input: String = format!("{:?}", i);
+            prop_assert_eq!(i, atof64_slice(input.as_bytes()));
+        }
+
+        #[test]
+        fn f64_roundtrip_scientific_proptest(i in f64::MIN..f64::MAX) {
+            let input: String = format!("{:e}", i);
+            prop_assert_eq!(i, atof64_slice(input.as_bytes()));
         }
     }
 }

--- a/lexical-core/src/atof/api.rs
+++ b/lexical-core/src/atof/api.rs
@@ -437,18 +437,21 @@ mod tests {
             prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
         }
 
+        #[cfg(feature = "correct")]
         #[test]
         fn f32_roundtrip_display_proptest(i in f32::MIN..f32::MAX) {
             let input: String = format!("{}", i);
             prop_assert_eq!(i, atof32_slice(input.as_bytes()));
         }
 
+        #[cfg(feature = "correct")]
         #[test]
         fn f32_roundtrip_debug_proptest(i in f32::MIN..f32::MAX) {
             let input: String = format!("{:?}", i);
             prop_assert_eq!(i, atof32_slice(input.as_bytes()));
         }
 
+        #[cfg(feature = "correct")]
         #[test]
         fn f32_roundtrip_scientific_proptest(i in f32::MIN..f32::MAX) {
             let input: String = format!("{:e}", i);
@@ -491,18 +494,21 @@ mod tests {
             prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
         }
 
+        #[cfg(feature = "correct")]
         #[test]
         fn f64_roundtrip_display_proptest(i in f64::MIN..f64::MAX) {
             let input: String = format!("{}", i);
             prop_assert_eq!(i, atof64_slice(input.as_bytes()));
         }
 
+        #[cfg(feature = "correct")]
         #[test]
         fn f64_roundtrip_debug_proptest(i in f64::MIN..f64::MAX) {
             let input: String = format!("{:?}", i);
             prop_assert_eq!(i, atof64_slice(input.as_bytes()));
         }
 
+        #[cfg(feature = "correct")]
         #[test]
         fn f64_roundtrip_scientific_proptest(i in f64::MIN..f64::MAX) {
             let input: String = format!("{:e}", i);

--- a/lexical-core/src/atoi.rs
+++ b/lexical-core/src/atoi.rs
@@ -599,273 +599,273 @@ mod tests {
         #[test]
         fn u8_invalid_proptest(i in r"[+]?[0-9]{2}\D") {
             let res = try_atou8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 2 || res.error.index == 3);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 2 || res.error.index == 3);
         }
 
         #[test]
         fn u8_overflow_proptest(i in r"[+-]?[1-9][0-9]{3}\D") {
             let res = try_atou8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::Overflow);
+            prop_assert_eq!(res.error.code, ErrorCode::Overflow);
         }
 
         #[test]
         fn u8_double_sign_proptest(i in r"[+-]{2}[0-9]{2}") {
             let res = try_atou8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0 || res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0 || res.error.index == 1);
         }
 
         #[test]
         fn u8_sign_only_proptest(i in r"[+-]") {
             let res = try_atou8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0);
         }
 
         #[test]
         fn u8_trailing_digits_proptest(i in r"[+]?[0-9]{2}\D[0-9]{2}") {
             let res = try_atou8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 2 || res.error.index == 3);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 2 || res.error.index == 3);
         }
 
         #[test]
         fn i8_invalid_proptest(i in r"[+-]?[0-9]{2}\D") {
             let res = try_atoi8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 2 || res.error.index == 3);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 2 || res.error.index == 3);
         }
 
         #[test]
         fn i8_overflow_proptest(i in r"[+-]?[1-9][0-9]{3}\D") {
             let res = try_atoi8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::Overflow);
+            prop_assert_eq!(res.error.code, ErrorCode::Overflow);
         }
 
         #[test]
         fn i8_double_sign_proptest(i in r"[+-]{2}[0-9]{2}") {
             let res = try_atoi8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 1);
         }
 
         #[test]
         fn i8_sign_only_proptest(i in r"[+-]") {
             let res = try_atoi8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0);
         }
 
         #[test]
         fn i8_trailing_digits_proptest(i in r"[+-]?[0-9]{2}\D[0-9]{2}") {
             let res = try_atoi8_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 2 || res.error.index == 3);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 2 || res.error.index == 3);
         }
 
         #[test]
         fn u16_invalid_proptest(i in r"[+]?[0-9]{4}\D") {
             let res = try_atou16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 4 || res.error.index == 5);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 4 || res.error.index == 5);
         }
 
         #[test]
         fn u16_overflow_proptest(i in r"[+-]?[1-9][0-9]{5}\D") {
             let res = try_atou16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::Overflow);
+            prop_assert_eq!(res.error.code, ErrorCode::Overflow);
         }
 
         #[test]
         fn u16_double_sign_proptest(i in r"[+-]{2}[0-9]{4}") {
             let res = try_atou16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0 || res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0 || res.error.index == 1);
         }
 
         #[test]
         fn u16_sign_only_proptest(i in r"[+-]") {
             let res = try_atou16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0);
         }
 
         #[test]
         fn u16_trailing_digits_proptest(i in r"[+]?[0-9]{4}\D[0-9]{2}") {
             let res = try_atou16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 4 || res.error.index == 5);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 4 || res.error.index == 5);
         }
 
         #[test]
         fn i16_invalid_proptest(i in r"[+-]?[0-9]{4}\D") {
             let res = try_atoi16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 4 || res.error.index == 5);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 4 || res.error.index == 5);
         }
 
         #[test]
         fn i16_overflow_proptest(i in r"[+-]?[1-9][0-9]{5}\D") {
             let res = try_atoi16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::Overflow);
+            prop_assert_eq!(res.error.code, ErrorCode::Overflow);
         }
 
         #[test]
         fn i16_double_sign_proptest(i in r"[+-]{2}[0-9]{4}") {
             let res = try_atoi16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 1);
         }
 
         #[test]
         fn i16_sign_only_proptest(i in r"[+-]") {
             let res = try_atoi16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0);
         }
 
         #[test]
         fn i16_trailing_digits_proptest(i in r"[+-]?[0-9]{4}\D[0-9]{2}") {
             let res = try_atoi16_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 4 || res.error.index == 5);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 4 || res.error.index == 5);
         }
 
         #[test]
         fn u32_invalid_proptest(i in r"[+]?[0-9]{9}\D") {
             let res = try_atou32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 9 || res.error.index == 10);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 9 || res.error.index == 10);
         }
 
         #[test]
         fn u32_overflow_proptest(i in r"[+-]?[1-9][0-9]{10}\D") {
             let res = try_atou32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::Overflow);
+            prop_assert_eq!(res.error.code, ErrorCode::Overflow);
         }
 
         #[test]
         fn u32_double_sign_proptest(i in r"[+-]{2}[0-9]{9}") {
             let res = try_atou32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0 || res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0 || res.error.index == 1);
         }
 
         #[test]
         fn u32_sign_only_proptest(i in r"[+-]") {
             let res = try_atou32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0);
         }
 
         #[test]
         fn u32_trailing_digits_proptest(i in r"[+]?[0-9]{9}\D[0-9]{2}") {
             let res = try_atou32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 9 || res.error.index == 10);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 9 || res.error.index == 10);
         }
 
         #[test]
         fn i32_invalid_proptest(i in r"[+-]?[0-9]{9}\D") {
             let res = try_atoi32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 9 || res.error.index == 10);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 9 || res.error.index == 10);
         }
 
         #[test]
         fn i32_overflow_proptest(i in r"[+-]?[1-9][0-9]{10}\D") {
             let res = try_atoi32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::Overflow);
+            prop_assert_eq!(res.error.code, ErrorCode::Overflow);
         }
 
         #[test]
         fn i32_double_sign_proptest(i in r"[+-]{2}[0-9]{9}") {
             let res = try_atoi32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 1);
         }
 
         #[test]
         fn i32_sign_only_proptest(i in r"[+-]") {
             let res = try_atoi32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0);
         }
 
         #[test]
         fn i32_trailing_digits_proptest(i in r"[+-]?[0-9]{9}\D[0-9]{2}") {
             let res = try_atoi32_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 9 || res.error.index == 10);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 9 || res.error.index == 10);
         }
 
         #[test]
         fn u64_invalid_proptest(i in r"[+]?[0-9]{19}\D") {
             let res = try_atou64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 19 || res.error.index == 20);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 19 || res.error.index == 20);
         }
 
         #[test]
         fn u64_overflow_proptest(i in r"[+-]?[1-9][0-9]{21}\D") {
             let res = try_atou64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::Overflow);
+            prop_assert_eq!(res.error.code, ErrorCode::Overflow);
         }
 
         #[test]
         fn u64_double_sign_proptest(i in r"[+-]{2}[0-9]{19}") {
             let res = try_atou64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0 || res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0 || res.error.index == 1);
         }
 
         #[test]
         fn u64_sign_only_proptest(i in r"[+-]") {
             let res = try_atou64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0);
         }
 
         #[test]
         fn u64_trailing_digits_proptest(i in r"[+]?[0-9]{19}\D[0-9]{2}") {
             let res = try_atou64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 19 || res.error.index == 20);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 19 || res.error.index == 20);
         }
 
         #[test]
         fn i64_invalid_proptest(i in r"[+-]?[0-9]{18}\D") {
             let res = try_atoi64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 18 || res.error.index == 19);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 18 || res.error.index == 19);
         }
 
         #[test]
         fn i64_overflow_proptest(i in r"[+-]?[1-9][0-9]{19}\D") {
             let res = try_atoi64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::Overflow);
+            prop_assert_eq!(res.error.code, ErrorCode::Overflow);
         }
 
         #[test]
         fn i64_double_sign_proptest(i in r"[+-]{2}[0-9]{18}") {
             let res = try_atoi64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 1);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 1);
         }
 
         #[test]
         fn i64_sign_only_proptest(i in r"[+-]") {
             let res = try_atoi64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 0);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 0);
         }
 
         #[test]
         fn i64_trailing_digits_proptest(i in r"[+-]?[0-9]{18}\D[0-9]{2}") {
             let res = try_atoi64_slice(i.as_bytes());
-            assert_eq!(res.error.code, ErrorCode::InvalidDigit);
-            assert!(res.error.index == 18 || res.error.index == 19);
+            prop_assert_eq!(res.error.code, ErrorCode::InvalidDigit);
+            prop_assert!(res.error.index == 18 || res.error.index == 19);
         }
     }
 }

--- a/lexical-core/src/ftoa/api.rs
+++ b/lexical-core/src/ftoa/api.rs
@@ -459,15 +459,15 @@ mod tests {
     #[cfg(feature = "correct")]
     proptest! {
         #[test]
-        fn f332_proptest(i in f32::MIN..f32::MAX) {
+        fn f32_proptest(i in f32::MIN..f32::MAX) {
             let mut buffer = new_buffer();
-            i == atof32_slice(f32toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atof32_slice(f32toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn f64_proptest(i in f64::MIN..f64::MAX) {
             let mut buffer = new_buffer();
-            i == atof64_slice(f64toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atof64_slice(f64toa_slice(i, &mut buffer)));
         }
     }
 

--- a/lexical-core/src/itoa.rs
+++ b/lexical-core/src/itoa.rs
@@ -574,73 +574,73 @@ mod tests {
         #[test]
         fn u8_proptest(i in u8::min_value()..u8::max_value()) {
             let mut buffer = new_buffer();
-            i == atou8_slice(u8toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atou8_slice(u8toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn i8_proptest(i in i8::min_value()..i8::max_value()) {
             let mut buffer = new_buffer();
-            i == atoi8_slice(i8toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atoi8_slice(i8toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn u16_proptest(i in u16::min_value()..u16::max_value()) {
             let mut buffer = new_buffer();
-            i == atou16_slice(u16toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atou16_slice(u16toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn i16_proptest(i in i16::min_value()..i16::max_value()) {
             let mut buffer = new_buffer();
-            i == atoi16_slice(i16toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atoi16_slice(i16toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn u32_proptest(i in u32::min_value()..u32::max_value()) {
             let mut buffer = new_buffer();
-            i == atou32_slice(u32toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atou32_slice(u32toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn i32_proptest(i in i32::min_value()..i32::max_value()) {
             let mut buffer = new_buffer();
-            i == atoi32_slice(i32toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atoi32_slice(i32toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn u64_proptest(i in u64::min_value()..u64::max_value()) {
             let mut buffer = new_buffer();
-            i == atou64_slice(u64toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atou64_slice(u64toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn i64_proptest(i in i64::min_value()..i64::max_value()) {
             let mut buffer = new_buffer();
-            i == atoi64_slice(i64toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atoi64_slice(i64toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn u128_proptest(i in u128::min_value()..u128::max_value()) {
             let mut buffer = new_buffer();
-            i == atou128_slice(u128toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atou128_slice(u128toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn i128_proptest(i in i128::min_value()..i128::max_value()) {
             let mut buffer = new_buffer();
-            i == atoi128_slice(i128toa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atoi128_slice(i128toa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn usize_proptest(i in usize::min_value()..usize::max_value()) {
             let mut buffer = new_buffer();
-            i == atousize_slice(usizetoa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atousize_slice(usizetoa_slice(i, &mut buffer)));
         }
 
         #[test]
         fn isize_proptest(i in isize::min_value()..isize::max_value()) {
             let mut buffer = new_buffer();
-            i == atoisize_slice(isizetoa_slice(i, &mut buffer))
+            prop_assert_eq!(i, atoisize_slice(isizetoa_slice(i, &mut buffer)));
         }
     }
 


### PR DESCRIPTION
After [your comment on issue#20](https://github.com/Alexhuszagh/rust-lexical/issues/20#issuecomment-516523638), I had a look at the existing tests, and I think I found why they're not finding any bugs for you. (Details in the commit message.)

I've run `cargo test` by hand a few times but there haven't been any new failures.