### PR TITLE
impl std::error::Error for lexical::Error

### DIFF
--- a/lexical-core/src/util/error.rs
+++ b/lexical-core/src/util/error.rs
@@ -1,5 +1,8 @@
 //! C-compatible error type.
 
+use std::error::Error as StdError;
+use std::fmt;
+
 /// Error code, indicating failure type.
 ///
 /// Error messages are designating by an error code of less than 0.
@@ -91,5 +94,17 @@ impl From<(ErrorCode, usize)> for Error {
     #[inline]
     fn from(error: (ErrorCode, usize)) -> Self {
         Error { code: error.0, index: error.1 }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "lexical error: {:?} at index {}.", self.code, self.index)
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        None
     }
 }


### PR DESCRIPTION
Adds std::error::Error implementation for lexical::Error.  This is useful when exposing a lexical::Error through a wrapping-error's source or cause method. See #39 (also #11).