### PR TITLE
Support no_std use of lexical-core by adjusting the arrayvec dependency

### DIFF
--- a/lexical-core/Cargo.toml
+++ b/lexical-core/Cargo.toml
@@ -27,7 +27,7 @@ cfg-if = "0.1"
 # Use static_assertions for correct or format features.
 static_assertions = { version = "1", optional = true }
 # Use arrayvec for the correct parser.
-arrayvec = { version = "0.5", optional = true, features = ["array-sizes-33-128"] }
+arrayvec = { version = "0.5", default-features = false, optional = true, features = ["array-sizes-33-128"] }
 # Optimized Grisu3 implementation, a well-tested, correct algorithm.
 dtoa = { version = "0.4", optional = true }
 # Optimized Ryu implementation, the fastest correct algorithm.


### PR DESCRIPTION
The `arrayvec` crate has a default feature "std" which makes the crate unsuitable for use in no_std environments. Luckily, `lexical-core` only ever uses arrayvec without leaning on capabilities provided by that feature. 

This PR simply removes the use of `arrayvec`'s default features, making `lexical-core` suitable for no_std builds.

I sanity-checked the efficacy of this with the [cargo-nono tool](https://github.com/hobofan/cargo-nono).

Before:
```
>~/Code/rust-lexical/lexical-core$ cargo nono check
lexical-core: SUCCESS
cfg-if: SUCCESS
bitflags: SUCCESS
ryu: SUCCESS
arrayvec: FAILURE
  - Crate supports no_std if "std" feature is deactivated.
    - Caused by feature flag "std" in crate "arrayvec:0.5.1"
      - Caused by feature flag "default" in crate "arrayvec:0.5.1"
        - Caused by implicitly enabled default feature from "lexical-core:0.7.4"
static_assertions: SUCCESS

```

After:
```
> ~/Code/rust-lexical/lexical-core$ cargo nono check
lexical-core: SUCCESS
bitflags: SUCCESS
arrayvec: SUCCESS
cfg-if: SUCCESS
static_assertions: SUCCESS
ryu: SUCCESS
```