### PR TITLE
Silence unused doc warnings

### DIFF
--- a/lexical-core/src/lib.rs
+++ b/lexical-core/src/lib.rs
@@ -126,6 +126,9 @@
 //! [`set_inf_string`]: fn.set_inf_string.html
 //! [`set_infinity_string`]: fn.set_infinity_string.html
 
+// silence warnings for unused doc comments
+#![allow(unused_doc_comments)]
+
 // FEATURES
 
 // Require intrinsics in a no_std context.


### PR DESCRIPTION
While compiling this crate, a huge amount of warnings are generated (~180), which seem to be caused by the `cfg_if` macro?

This PR adds an attribute to `lib.rs` that silences those warnings