### PR TITLE
Use fully-qualified syntax for `::BITS` and prep for stdlib stabilization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 name = "lexical"
 readme = "README.md"
 repository = "https://github.com/Alexhuszagh/rust-lexical"
-version = "5.2.0"
+version = "5.2.1"
 exclude = [
     "data/*",
     "benches/*",

--- a/lexical-core/src/atof/algorithm/bhcomp.rs
+++ b/lexical-core/src/atof/algorithm/bhcomp.rs
@@ -59,7 +59,7 @@ pub(super) fn parse_mantissa<'a, Data>(data: Data, radix: u32, max_digits: usize
     let small_powers = Bigint::small_powers(radix);
     let count = data.mantissa_digits();
     let bits = count / integral_binary_factor(radix).as_usize();
-    let bytes = bits / Limb::BITS;
+    let bytes = bits / (<Limb as crate::util::Integer>::BITS as usize);
 
     // Main loop
     let step = small_powers.len() - 2;
@@ -283,7 +283,7 @@ pub(super) fn large_atof<'a, F, Data>(data: Data, radix: u32, max_digits: usize,
 
     // Get the exact representation of the float from the big integer.
     let (mant, is_truncated) = bigmant.hi64();
-    let exp = bigmant.bit_length().as_i32() - u64::BITS.as_i32();
+    let exp = bigmant.bit_length().as_i32() - <u64 as crate::util::Integer>::BITS.as_i32();
     let mut fp = ExtendedFloat { mant: mant, exp: exp };
     round_to_native::<F>(&mut fp, is_truncated, kind);
     into_float(fp)

--- a/lexical-core/src/atof/algorithm/bigcomp.rs
+++ b/lexical-core/src/atof/algorithm/bigcomp.rs
@@ -154,7 +154,7 @@ pub(super) fn make_ratio<F: Float>(radix: u32, sci_exponent: i32, f: F, kind: Ro
     // Scale the denominator so it has the number of bits
     // in the radix as the number of leading zeros.
     let wlz = integral_binary_factor(radix).as_usize();
-    let nlz = den.leading_zeros().wrapping_sub(wlz) & (u32::BITS - 1);
+    let nlz = den.leading_zeros().wrapping_sub(wlz) & (<u32 as crate::util::Integer>::BITS as usize - 1);
     small::ishl_bits(den.data_mut(), nlz);
     den.exp -= nlz.as_i32();
 
@@ -172,7 +172,7 @@ pub(super) fn make_ratio<F: Float>(radix: u32, sci_exponent: i32, f: F, kind: Ro
         // denominator will be normalized.
         // We need to add one to the quotient,since we're calculating the
         // ceiling of the divmod.
-        let (q, r) = shift.ceil_divmod(Limb::BITS);
+        let (q, r) = shift.ceil_divmod(<Limb as crate::util::Integer>::BITS as usize);
         // Since we're using a power from the denominator to the
         // numerator, we to invert r, not add u32::BITS.
         let r = -r;
@@ -180,7 +180,7 @@ pub(super) fn make_ratio<F: Float>(radix: u32, sci_exponent: i32, f: F, kind: Ro
         num.exp -= r;
         if !q.is_zero() {
             den.pad_zero_digits(q);
-            den.exp -= Limb::BITS.as_i32() * q.as_i32();
+            den.exp -= <Limb as crate::util::Integer>::BITS.as_i32() * q.as_i32();
         }
     }
 

--- a/lexical-core/src/util/num.rs
+++ b/lexical-core/src/util/num.rs
@@ -133,7 +133,7 @@ pub trait Integer:
     const TWO: Self;
     const MAX: Self;
     const MIN: Self;
-    const BITS: usize;
+    const BITS: u32;
 
     // FUNCTIONS (INHERITED)
     fn max_value() -> Self;
@@ -370,7 +370,7 @@ macro_rules! integer_impl {
             const TWO: $t = 2;
             const MAX: $t = $t::max_value();
             const MIN: $t = $t::min_value();
-            const BITS: usize = mem::size_of::<$t>() * 8;
+            const BITS: u32 = (mem::size_of::<$t>() * 8) as u32;
 
             #[inline]
             fn max_value() -> Self {


### PR DESCRIPTION
This commit **only** replaces each unqualified use of `$type::BITS` with `<$type as crate::util::Integer>::BITS as usize`, and marks the `Integer::BITS` constant as a `u32`.

This change allows `core` to stabilize the `BITS` constant on the integer primitives.

Once `core` stabilizes the constant, you can replace the definition from `mem::size_of::<$t>() * 8` to `<$t>::BITS`. You will also be able to strip the `< as crate::util::Integer>::` qualification syntax from most of the use sites, which use known typenames rather than trait-only generics.

----

In a followup PR, if you assent, I will replace much of the `Integer` trait with my [`funty`](https://github.com/myrrlyn/funty) crate so that you do not need to have the maintenance burden of integer typing going forward.