### PR TITLE
disable default features in lexical-util dependency for lexical-parse-float, close issue #72

### DIFF
--- a/lexical-parse-float/Cargo.toml
+++ b/lexical-parse-float/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
 [dependencies.lexical-util]
 version = "0.8"
 path = "../lexical-util"
+default-features = false
 features = ["parse-floats"]
 
 [dependencies.lexical-parse-integer]


### PR DESCRIPTION
Removes a dependency to std which originates in the lexical-util dependency of lexical-parse-float, which made the crate not usable in no_std. Closes issue #72 