### PR TITLE
WIP fixing miri (with -Zmiri-tag-raw-pointers) errors

### DIFF
--- a/lexical-write-float/src/algorithm.rs
+++ b/lexical-write-float/src/algorithm.rs
@@ -238,6 +238,8 @@ pub unsafe fn write_float_negative_exponent<F: DragonboxFloat, const FORMAT: u12
 ///
 /// Safe as long as `bytes` is large enough to hold the number of
 /// significant digits and the (optional) trailing zeros.
+// TODO: There is a bug here... but i do not know where
+// run `MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo miri test f32_roundtrip_test` to find it.
 pub unsafe fn write_float_positive_exponent<F: DragonboxFloat, const FORMAT: u128>(
     bytes: &mut [u8],
     fp: ExtendedFloat80,


### PR DESCRIPTION
When running miri with `-Zmiri-tag-raw-pointers`, I get errors.

Miri should be ran in CI with this flag set.

The issues here are partly stacked borrows issues (needing me to refactor the `as_mut_ptr()` and `len()` calls to be done in the right order), and partly provenance (`as_mut_ptr()` was originally dereferencing to a slice, which didn't give a pointer with provenance that was allowed to write outside of its length).

The provenance issue was fixed by introducing as_mut_ptr() that used the array in full.