### PR TITLE
Fix compilation failure in lexical-write-float-correctness

### DIFF
--- a/lexical-write-float/etc/correctness/Cargo.toml
+++ b/lexical-write-float/etc/correctness/Cargo.toml
@@ -15,8 +15,11 @@ path = "../../../lexical-util"
 default-features = false
 features = []
 
+[dependencies.clap]
+version = "3.1.18"
+features = ["derive"]
+
 [dependencies]
-clap = "3.0.0-beta.4"
 fastrand = "1.4"
 
 [features]

--- a/lexical-write-float/etc/correctness/dragonbox/opts.rs
+++ b/lexical-write-float/etc/correctness/dragonbox/opts.rs
@@ -1,9 +1,8 @@
 // Shared command-line options.
 
-use clap::{AppSettings, Clap};
+use clap::Parser;
 
-#[derive(Clap)]
-#[clap(setting = AppSettings::ColoredHelp)]
+#[derive(Parser)]
 pub struct Opts {
     #[clap(short, long, default_value = "10000000")]
     pub iterations: usize,

--- a/lexical-write-float/etc/correctness/dragonbox/random.rs
+++ b/lexical-write-float/etc/correctness/dragonbox/random.rs
@@ -7,7 +7,7 @@ mod roundtrip;
 
 use clap::Parser;
 use lexical_write_float::float::RawFloat;
-use lexical_write_float::{BUFFER_SIZE, ToLexical};
+use lexical_write_float::{ToLexical, BUFFER_SIZE};
 use opts::Opts;
 use roundtrip::roundtrip;
 
@@ -72,7 +72,7 @@ macro_rules! float_rng {
 float_rng! { f32 f64 }
 
 macro_rules! random {
-    ($name:ident, $cb:ident) => (
+    ($name:ident, $cb:ident) => {
         fn $name<F>(count: usize) -> Result<(), String>
         where
             F: FloatRng + ToLexical + std::str::FromStr + std::string::ToString,
@@ -84,7 +84,7 @@ macro_rules! random {
             }
             Ok(())
         }
-    );
+    };
 }
 
 random!(uniform_random, uniform);

--- a/lexical-write-float/etc/correctness/dragonbox/random.rs
+++ b/lexical-write-float/etc/correctness/dragonbox/random.rs
@@ -5,7 +5,7 @@
 mod opts;
 mod roundtrip;
 
-use clap::Clap;
+use clap::Parser;
 use lexical_write_float::float::RawFloat;
 use lexical_write_float::{BUFFER_SIZE, ToLexical};
 use opts::Opts;

--- a/lexical-write-float/etc/correctness/dragonbox/roundtrip.rs
+++ b/lexical-write-float/etc/correctness/dragonbox/roundtrip.rs
@@ -17,7 +17,7 @@ where
         float == roundtrip
     };
     if !is_equal {
-        return Err(float.to_string())
+        return Err(float.to_string());
     }
     Ok(())
 }

--- a/lexical-write-float/etc/correctness/dragonbox/shorter_interval.rs
+++ b/lexical-write-float/etc/correctness/dragonbox/shorter_interval.rs
@@ -4,7 +4,7 @@
 
 use lexical_util::num::as_cast;
 use lexical_write_float::float::RawFloat;
-use lexical_write_float::{BUFFER_SIZE, ToLexical};
+use lexical_write_float::{ToLexical, BUFFER_SIZE};
 
 fn shorter_interval_test<F>() -> Result<(), String>
 where
@@ -17,7 +17,7 @@ where
         let string = unsafe { std::str::from_utf8_unchecked(float.to_lexical(&mut buffer)) };
         let roundtrip = string.parse::<F>().map_err(|_| float.to_string())?;
         if roundtrip != float {
-            return Err(float.to_string())
+            return Err(float.to_string());
         }
     }
     Ok(())

--- a/lexical-write-float/etc/correctness/dragonbox/simple_random.rs
+++ b/lexical-write-float/etc/correctness/dragonbox/simple_random.rs
@@ -5,7 +5,7 @@
 mod opts;
 mod roundtrip;
 
-use clap::Clap;
+use clap::Parser;
 use lexical_write_float::BUFFER_SIZE;
 use opts::Opts;
 use roundtrip::roundtrip;


### PR DESCRIPTION
Updates `clap` to `3.1.8` from `3.0.0-beta.4` in the `lexcial-write-float` correctness tests.

This should solve one of the failures in CI. According to https://doc.rust-lang.org/cargo/reference/resolver.html#pre-releases, "*Cargo allows "newer" pre-releases to be used automatically*", thus I believe this was broken since the release of `3.0.0-rc.0`, which renamed `trait Clap` to `Parser` and removed feature `derive` from `default`.

Also ran `cargo +nightly fmt` once in a separate commit, on just that folder.