### PR TITLE
Suppress some lints that trigger don't trigger in all cfg's

### DIFF
--- a/lexical-benchmark/input.rs
+++ b/lexical-benchmark/input.rs
@@ -90,6 +90,7 @@ macro_rules! json_data {
 }
 
 /// Generate an array of values as static data
+#[allow(unknown_lints, unused_macro_rules)]
 macro_rules! static_data {
     ($($fn:ident $cb:ident $f1:ident $t:tt ; )*) => ($(
         fn $fn() -> &'static [$t] {

--- a/lexical-parse-float/src/index.rs
+++ b/lexical-parse-float/src/index.rs
@@ -16,6 +16,7 @@ macro_rules! index_unchecked {
 
 /// Index a buffer and get a mutable reference, without bounds checking.
 #[cfg(not(feature = "safe"))]
+#[allow(unknown_lints, unused_macro_rules)]
 macro_rules! index_unchecked_mut {
     ($x:ident[$i:expr]) => {
         *$x.get_unchecked_mut($i)
@@ -32,6 +33,7 @@ macro_rules! index_unchecked {
 
 /// Index a buffer and get a mutable reference, with bounds checking.
 #[cfg(feature = "safe")]
+#[allow(unknown_lints, unused_macro_rules)]
 macro_rules! index_unchecked_mut {
     ($x:ident[$i:expr]) => {
         $x[$i]

--- a/lexical-write-integer/src/index.rs
+++ b/lexical-write-integer/src/index.rs
@@ -21,6 +21,7 @@ macro_rules! index_unchecked {
 // The newer version of the lint is `unused_macro_rules`, but this isn't
 // supported until nightly-2022-05-12.
 #[cfg(not(feature = "safe"))]
+#[allow(unknown_lints, unused_macro_rules)]
 macro_rules! index_unchecked_mut {
     ($x:ident[$i:expr]) => {
         *$x.get_unchecked_mut($i)
@@ -52,6 +53,7 @@ macro_rules! index_unchecked {
 // The newer version of the lint is `unused_macro_rules`, but this isn't
 // supported until nightly-2022-05-12.
 #[cfg(feature = "safe")]
+#[allow(unknown_lints, unused_macro_rules)]
 macro_rules! index_unchecked_mut {
     ($x:ident[$i:expr]) => {
         $x[$i]


### PR DESCRIPTION
This `allows` a new nightly lint (rust-lang/rust#96150) on some macros that trigger because of how they interact with `cfg` attributes. From my point-of-view, it didn't make sense to replicate those `cfg` in an `cfg_attr` here. There's another case in my [`patch-5`](https://github.com/Alexhuszagh/rust-lexical/commit/0c1fc32370af22450c182ec853dc270de2261e8c) branch, which might not be a false-positive like these ones.