### PR TITLE
Ruby float literal format improvements:

### DIFF
--- a/lexical-parse-float/src/options.rs
+++ b/lexical-parse-float/src/options.rs
@@ -602,20 +602,21 @@ const_assert!(CXX_LITERAL.is_valid());
 #[rustfmt::skip]
 pub const RUBY_LITERAL: Options = unsafe {
     Options::builder()
-        .nan_string(options::RUBY)
-        .inf_string(options::RUBY)
-        .infinity_string(options::RUBY)
+        .nan_string(options::RUBY_LITERAL_NAN)
+        .inf_string(options::RUBY_LITERAL_INF)
+        .infinity_string(options::RUBY_LITERAL_INF)
         .build_unchecked()
 };
 const_assert!(RUBY_LITERAL.is_valid());
 
 /// Number format to parse a Ruby float from string.
+/// Ruby can write NaN and Infinity as strings, but won't roundtrip them back to floats.
 #[rustfmt::skip]
 pub const RUBY_STRING: Options = unsafe {
     Options::builder()
-        .nan_string(options::RUBY)
-        .inf_string(options::RUBY)
-        .infinity_string(options::RUBY)
+        .nan_string(options::RUBY_STRING_NONE)
+        .inf_string(options::RUBY_STRING_NONE)
+        .infinity_string(options::RUBY_STRING_NONE)
         .build_unchecked()
 };
 const_assert!(RUBY_STRING.is_valid());

--- a/lexical-util/src/feature_format.rs
+++ b/lexical-util/src/feature_format.rs
@@ -1725,6 +1725,7 @@ const_assert!(NumberFormat::<{ C89_HEX_STRING }> {}.is_valid());
 #[rustfmt::skip]
 pub const RUBY_LITERAL: u128 = NumberFormatBuilder::new()
     .digit_separator(num::NonZeroU8::new(b'_'))
+    .required_exponent_sign(true)
     .required_digits(true)
     .no_special(true)
     .no_integer_leading_zeros(true)

--- a/lexical-util/src/options.rs
+++ b/lexical-util/src/options.rs
@@ -53,8 +53,11 @@ literal!(CXX_LITERAL_INFINITY, b"INFINITY");
 literal!(C_LITERAL_NAN, b"NAN");
 literal!(C_LITERAL_INF, b"INFINITY");
 literal!(C_LITERAL_INFINITY, b"INFINITY");
+// RUBY_LITERAL
+literal!(RUBY_LITERAL_NAN, b"NaN");
+literal!(RUBY_LITERAL_INF, b"Infinity");
+literal!(RUBY_STRING_NONE, None);
 // C_STRING
-literal!(RUBY, None);
 literal!(SWIFT_LITERAL, None);
 // SWIFT_STRING
 literal!(GO_LITERAL, None);

--- a/lexical-write-float/src/options.rs
+++ b/lexical-write-float/src/options.rs
@@ -835,8 +835,10 @@ const_assert!(CXX_LITERAL.is_valid());
 #[rustfmt::skip]
 pub const RUBY_LITERAL: Options = unsafe {
     Options::builder()
-        .nan_string(options::RUBY)
-        .inf_string(options::RUBY)
+        .positive_exponent_break(num::NonZeroI32::new(14))
+        .negative_exponent_break(num::NonZeroI32::new(-4))
+        .nan_string(options::RUBY_LITERAL_NAN)
+        .inf_string(options::RUBY_LITERAL_INF)
         .build_unchecked()
 };
 const_assert!(RUBY_LITERAL.is_valid());
@@ -845,8 +847,8 @@ const_assert!(RUBY_LITERAL.is_valid());
 #[rustfmt::skip]
 pub const RUBY_STRING: Options = unsafe {
     Options::builder()
-        .nan_string(options::RUBY)
-        .inf_string(options::RUBY)
+        .nan_string(options::RUBY_LITERAL_NAN)
+        .inf_string(options::RUBY_LITERAL_INF)
         .build_unchecked()
 };
 const_assert!(RUBY_STRING.is_valid());


### PR DESCRIPTION
* Ruby floats are always formatted with an exponent sign.
* Ruby floats break to scientific at e-4.
* Ruby floats break to scientific at e14 (approximately).
* Ruby uses "Infinity" and "NaN", but "Infinity".to_f and "NaN".to_f are 0

The true behaviour for the positive exponent break is more subtle than this. In addition to this, values between 1.0e15 and 1.0e16 can take either decimal or exponent form depending on the number of significant digits. I did not find a sane way to replicate this behaviour here.