### PR TITLE
Don't extern alloc unless needed to avoid requiring global allocators in #[no_std] environments

### DIFF
--- a/lexical/src/lib.rs
+++ b/lexical/src/lib.rs
@@ -271,17 +271,13 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // Need an allocator for String/Vec.
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "write")]
 extern crate alloc;
 
-#[cfg(all(feature = "write", not(feature = "std")))]
+#[cfg(feature = "write")]
 use alloc::string::String;
-#[cfg(all(feature = "write", not(feature = "std")))]
+#[cfg(feature = "write")]
 use alloc::vec::Vec;
-#[cfg(all(feature = "write", feature = "std"))]
-use std::string::String;
-#[cfg(all(feature = "write", feature = "std"))]
-use std::vec::Vec;
 
 pub use lexical_core::format::{self, format_error, format_is_valid, NumberFormatBuilder};
 #[cfg(feature = "parse")]


### PR DESCRIPTION
Disabling the `std` feature causes `extern crate alloc` to be used, which in turn requires any downstream `#[no_std]` users to define a global allocator with a message like this:

```
error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait
```

This change ensures that we only use `extern crate alloc` when it's actually needed, which is when the `write` feature is enabled.

Also note that `std::string::String` and `std::vec::Vec` are [aliases for the corresponding `alloc` types](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=df39ce3e37c7a38ca54a620094b2e27b), so importing it through `std` when it's available is not necessary.

It would arguably be cleaner for `#![no_std]` to always be enabled and add the following where `std` types and items are used, but changing this is up to you:

```rust
#[cfg(feature = "std")]
extern crate std;
```