### PR TITLE
Document Internal Safety and Remove Most Unsafety

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,16 +1,34 @@
 #!/bin/bash
+# shellcheck disable=SC2086,SC2236
 # Run main test suite.
 
 set -ex
 
 # Change to our project home.
 script_dir=$(dirname "${BASH_SOURCE[0]}")
-cd "$script_dir"/..
+home=$(dirname "${script_dir}")
+cd "${home}"
 
 # Print our cargo version, for debugging.
 cargo --version
 
 # Test our Miri logic
 rustup component add --toolchain nightly miri &2 > /dev/null || true
+
+# these are our simple tests
 cargo +nightly miri test --all-features
 cargo +nightly miri test --features radix,format,write-integers,write-floats,parse-integers,parse-floats
+cargo +nightly miri test --no-default-features --features compact,format,write-integers,write-floats,parse-integers,parse-floats
+
+FEATURES=
+if [ ! -z $ALL_FEATURES ]; then
+    FEATURES=--all-features
+fi
+
+# we want comprehensive tests so let's do everything
+# Test the write-float correctness tests.
+cd "${home}"
+cd lexical-write-float/etc/correctness
+cargo run $FEATURES --release --bin shorter_interval
+cargo run $FEATURES --release --bin random
+cargo run $FEATURES --release --bin simple_random  -- --iterations 1000000

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -6,7 +6,8 @@ set -ex
 
 # Change to our project home.
 script_dir=$(dirname "${BASH_SOURCE[0]}")
-cd "$script_dir"/..
+home=$(dirname "${script_dir}")
+cd "${home}"
 
 # Print our cargo version, for debugging.
 cargo --version
@@ -78,6 +79,7 @@ test() {
     test_features="$DEFAULT_FEATURES --features=$REQUIRED_FEATURES"
     cargo test $test_features $DOCTESTS
     cargo test $test_features $DOCTESTS --release
+    cargo test --features=radix,format,compact $DOCTESTS --release
 }
 
 # Dry-run bench target

--- a/lexical-parse-float/src/parse.rs
+++ b/lexical-parse-float/src/parse.rs
@@ -3,6 +3,10 @@
 //! This is adapted from [fast-float-rust](https://github.com/aldanor/fast-float-rust),
 //! a port of [fast_float](https://github.com/fastfloat/fast_float) to Rust.
 
+// NOTE: We never want to disable multi-digit optimizations when parsing our floats,
+// since the nanoseconds it saves on branching is irrelevant when considering decimal
+// points and fractional digits and it majorly improves longer floats.
+
 #![doc(hidden)]
 
 #[cfg(any(feature = "compact", feature = "radix"))]

--- a/lexical-parse-integer/src/algorithm.rs
+++ b/lexical-parse-integer/src/algorithm.rs
@@ -316,8 +316,7 @@ where
 /// `u8::MAX` is `ff` - any str of len 2 is guaranteed to not overflow.
 /// `i8::MAX` is `7f` - only a str of len 1 is guaranteed to not overflow.
 ///
-/// This is based off of here:
-///     https://doc.rust-lang.org/1.81.0/src/core/num/mod.rs.html#1480
+/// This is based off of [core/num](core).
 ///
 /// * `value` - The current parsed value.
 /// * `iter` - An iterator over all bytes in the input.
@@ -325,6 +324,8 @@ where
 /// * `start_index` - The offset where parsing started.
 /// * `invalid_digit` - Behavior when an invalid digit is found.
 /// * `is_end` - If iter corresponds to the full input.
+///
+/// core: <https://doc.rust-lang.org/1.81.0/src/core/num/mod.rs.html#1480>
 macro_rules! parse_1digit_unchecked {
 ($value:ident, $iter:ident, $add_op:ident, $start_index:ident, $invalid_digit:ident, $is_end:expr) => {{
     // This is a slower parsing algorithm, going 1 digit at a time, but doing it in an unchecked loop.
@@ -344,8 +345,7 @@ macro_rules! parse_1digit_unchecked {
 
 /// Run a loop where the integer could overflow.
 ///
-/// This is a standard, unoptimized algorithm. This is based off of here:
-///     https://doc.rust-lang.org/1.81.0/src/core/num/mod.rs.html#1505
+/// This is a standard, unoptimized algorithm. This is based off of [core/num](core)
 ///
 /// * `value` - The current parsed value.
 /// * `iter` - An iterator over all bytes in the input.
@@ -353,6 +353,8 @@ macro_rules! parse_1digit_unchecked {
 /// * `start_index` - The offset where parsing started.
 /// * `invalid_digit` - Behavior when an invalid digit is found.
 /// * `overflow` - If the error is overflow or underflow.
+///
+/// core: <https://doc.rust-lang.org/1.81.0/src/core/num/mod.rs.html#1505>
 macro_rules! parse_1digit_checked {
 ($value:ident, $iter:ident, $add_op:ident, $start_index:ident, $invalid_digit:ident, $overflow:ident) => {{
     // This is a slower parsing algorithm, going 1 digit at a time, but doing it in an unchecked loop.
@@ -398,15 +400,15 @@ macro_rules! parse_digits_unchecked {
     // into `try_parse_8digits!` or `try_parse_4digits` it will be optimized out and the
     // overflow won't matter.
     let format = NumberFormat::<FORMAT> {};
-    let radix4 = T::from_u32(format.radix4());
-    let radix8 = T::from_u32(format.radix8());
     if use_multi && T::BITS >= 64 && $iter.length() >= 8 {
         // Try our fast, 8-digit at a time optimizations.
+        let radix8 = T::from_u32(format.radix8());
         while let Some(value) = try_parse_8digits::<T, _, FORMAT>(&mut $iter) {
             $value = $value.wrapping_mul(radix8).$add_op(value);
         }
     } else if use_multi && T::BITS == 32 && $iter.length() >= 4 {
         // Try our fast, 8-digit at a time optimizations.
+        let radix4 = T::from_u32(format.radix4());
         while let Some(value) = try_parse_4digits::<T, _, FORMAT>(&mut $iter) {
             $value = $value.wrapping_mul(radix4).$add_op(value);
         }

--- a/lexical-util/src/algorithm.rs
+++ b/lexical-util/src/algorithm.rs
@@ -1,18 +1,16 @@
 //! Simple, shared algorithms for slices and iterators.
 
 use crate::num::Integer;
-#[cfg(feature = "write")]
-use core::ptr;
 
 /// Copy bytes from source to destination.
+///
+/// This is only used in our compactt and radix integer formatted, so
+/// performance isn't the highest consideration here.
 #[inline(always)]
 #[cfg(feature = "write")]
 pub fn copy_to_dst<Bytes: AsRef<[u8]>>(dst: &mut [u8], src: Bytes) -> usize {
-    assert!(dst.len() >= src.as_ref().len());
-
-    // SAFETY: safe, if `dst.len() <= src.len()`.
     let src = src.as_ref();
-    unsafe { ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), src.len()) };
+    dst[..src.len()].clone_from_slice(src);
 
     src.len()
 }
@@ -31,29 +29,14 @@ pub fn ltrim_char_count(slc: &[u8], c: u8) -> usize {
     slc.iter().take_while(|&&si| si == c).count()
 }
 
-/// Trim character from the end (right-side) of a slice.
-#[inline(always)]
-#[cfg(feature = "write")]
-pub fn rtrim_char_slice(slc: &[u8], c: u8) -> (&[u8], usize) {
-    let count = rtrim_char_count(slc, c);
-    let index = slc.len() - count;
-    // Count must be <= slc.len(), and therefore, slc.len() - count must
-    // also be <= slc.len(), since this is derived from an iterator
-    // in the standard library.
-    debug_assert!(count <= slc.len());
-    debug_assert!(index <= slc.len());
-    // SAFETY: safe since `count <= slc.len()` and therefore `index <= slc.len()`.
-    let slc = unsafe { slc.get_unchecked(..index) };
-    (slc, count)
-}
-
 /// Check to see if parsing the float cannot possible overflow.
 ///
 /// This allows major optimizations for those types, since we can skip checked
 /// arithmetic.
 ///
-/// Adapted from the rust corelib:
-///     https://doc.rust-lang.org/1.81.0/src/core/num/mod.rs.html#1389
+/// Adapted from the rust [corelib](core).
+///
+/// core: <https://doc.rust-lang.org/1.81.0/src/core/num/mod.rs.html#1389>
 #[inline(always)]
 pub fn cannot_overflow<T: Integer>(length: usize, radix: u32) -> bool {
     length <= T::overflow_digits(radix)

--- a/lexical-util/src/assert.rs
+++ b/lexical-util/src/assert.rs
@@ -57,6 +57,7 @@ pub fn assert_radix<const FORMAT: u128>() {
 // BUFFER
 
 /// Debug assertion the buffer has sufficient room for the output.
+// TODO: Remove this entirely
 #[inline(always)]
 #[cfg(feature = "write")]
 pub fn debug_assert_buffer<T: FormattedSize>(radix: u32, len: usize) {

--- a/lexical-util/src/buffer.rs
+++ b/lexical-util/src/buffer.rs
@@ -4,7 +4,7 @@
 //! which then can be used for contiguous or non-contiguous iterables,
 //! including containers or iterators of any kind.
 
-#![cfg(feature = "parse")]
+use core::mem;
 
 /// A trait for working with iterables of bytes.
 ///
@@ -12,7 +12,15 @@
 /// methods for reading data and accessing underlying data. The readers
 /// can either be contiguous or non-contiguous, although performance and
 /// some API methods may not be available for both.
-pub trait Buffer<'a> {
+///
+/// # Safety
+///
+/// This trait is effectively safe but the implementor must guarantee that
+/// `is_empty` is implemented correctly. For most implementations, this can
+/// be `self.as_slice().is_empty()`, where `as_slice` is implemented as
+/// `&self.bytes[self.index..]`.
+#[cfg(feature = "parse")]
+pub unsafe trait Buffer<'a> {
     /// Determine if the buffer is contiguous in memory.
     const IS_CONTIGUOUS: bool;
 
@@ -24,9 +32,14 @@ pub trait Buffer<'a> {
 
     /// Get if no bytes are available in the buffer.
     ///
-    /// If this is an iterator, this is based left to be returned.
-    /// We do not necessarly know the length of the buffer
-    fn is_empty(&self) -> bool;
+    /// This operators on the underlying buffer: that is,
+    /// it returns if [as_slice] would return an empty slice.
+    ///
+    /// [as_slice]: Buffer::as_slice
+    #[inline(always)]
+    fn is_empty(&self) -> bool {
+        self.as_slice().is_empty()
+    }
 
     /// Determine if the buffer is contiguous.
     #[inline(always)]
@@ -45,10 +58,18 @@ pub trait Buffer<'a> {
     unsafe fn first_unchecked(&self) -> &'a u8;
 
     /// Get the next value available without consuming it.
+    ///
+    /// # Safety
+    ///
+    /// An implementor must implement `is_empty` correctly in
+    /// order to guarantee the traitt is safe: `is_empty` **MUST**
+    /// ensure that one value remains, if the iterator is non-
+    /// contiguous this means advancing the iterator to the next
+    /// position.
     #[inline(always)]
     fn first(&self) -> Option<&'a u8> {
         if !self.is_empty() {
-            // SAFETY: safe since the buffer cannot be empty
+            // SAFETY: safe since the buffer cannot be empty as validated before.
             unsafe { Some(self.first_unchecked()) }
         } else {
             None
@@ -74,4 +95,45 @@ pub trait Buffer<'a> {
             false
         }
     }
+}
+
+// NOTE: These two functions are taken directly from the Rust corelib.
+//  https://doc.rust-lang.org/1.81.0/src/core/mem/maybe_uninit.rs.html#964
+
+/// Assuming all the elements are initialized, get a slice to them.
+///
+/// # Safety
+///
+/// It is up to the caller to guarantee that the `MaybeUninit<T>` elements
+/// really are in an initialized state. Calling this when the content is not
+/// yet fully initialized causes undefined behavior.
+///
+/// See [`assume_init_ref`] for more details and examples.
+///
+/// [`assume_init_ref`]: mem::MaybeUninit::assume_init_ref
+#[inline(always)]
+pub const unsafe fn slice_assume_init<T>(slice: &[mem::MaybeUninit<T>]) -> &[T] {
+    // SAFETY: casting `slice` to a `*const [T]` is safe since the caller guarantees that
+    // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
+    // The pointer obtained is valid since it refers to memory owned by `slice` which is a
+    // reference and thus guaranteed to be valid for reads.
+    unsafe { &*(slice as *const [mem::MaybeUninit<T>] as *const [T]) }
+}
+
+// Assuming all the elements are initialized, get a mutable slice to them.
+///
+/// # Safety
+///
+/// It is up to the caller to guarantee that the `MaybeUninit<T>` elements
+/// really are in an initialized state. Calling this when the content is
+/// not yet fully initialized causes undefined behavior.
+///
+/// See [`assume_init_mut`] for more details and examples.
+///
+/// [`assume_init_mut`]: mem::MaybeUninit::assume_init_mut
+#[inline(always)]
+pub unsafe fn slice_assume_init_mut<T>(slice: &mut [mem::MaybeUninit<T>]) -> &mut [T] {
+    // SAFETY: similar to safety notes for `slice_get_ref`, but we have a
+    // mutable reference which is also guaranteed to be valid for writes.
+    unsafe { &mut *(slice as *mut [mem::MaybeUninit<T>] as *mut [T]) }
 }

--- a/lexical-util/src/constants.rs
+++ b/lexical-util/src/constants.rs
@@ -60,7 +60,7 @@ formatted_size_impl! {
     u64 20 128 ;
     u128 39 256 ;
     // The f64 buffer is actually a size of 60, but use 64 since it's a power of 2.
-    // Use 256 fir non-decimal values, actually, since we seem to have memory
+    // Use 256 for non-decimal values, actually, since we seem to have memory
     // issues with f64. Clearly not sufficient memory allocated for non-decimal
     // values.
     //bf16 64 256 ;

--- a/lexical-util/src/digit.rs
+++ b/lexical-util/src/digit.rs
@@ -98,17 +98,17 @@ pub const fn char_is_digit(c: u8, radix: u32) -> bool {
 
 /// Convert a digit to a character. This uses a pre-computed table to avoid branching.
 ///
-/// # Safety
+/// # Panics
 ///
-/// Safe as long as `digit < 36`.
+/// Panics if `digit >= 36`.
 #[inline(always)]
 #[cfg(feature = "write")]
-pub unsafe fn digit_to_char(digit: u32) -> u8 {
+pub fn digit_to_char(digit: u32) -> u8 {
     const TABLE: [u8; 36] = [
         b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'A', b'B', b'C', b'D', b'E',
         b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O', b'P', b'Q', b'R', b'S', b'T',
         b'U', b'V', b'W', b'X', b'Y', b'Z',
     ];
     debug_assert!(digit < 36, "digit_to_char() invalid character.");
-    unsafe { *TABLE.get_unchecked(digit as usize) }
+    TABLE[digit as usize]
 }

--- a/lexical-util/src/lib.rs
+++ b/lexical-util/src/lib.rs
@@ -34,6 +34,70 @@
 //!
 //! The minimum, standard, required version is 1.63.0, for const generic
 //! support. Older versions of lexical support older Rust versions.
+//!
+//! # Safety Guarantees
+//!
+//! The only major sources of unsafe code are wrapped in the `iterator.rs`,
+//! `skip.rs`, and `noskip.rs`. These are fully encapsulated into standalone
+//! traits to clearly define safety invariants and localize any unsafety to
+//! 1 or 2 lines of code.
+//!
+//! The core, unsafe trait is `BytesIter` and `Buffer`, both which expect
+//! to be backed by a contiguous block of memory (a slice) but may skip
+//! bytes internally. To guarantee safety, for non-skip iterators you
+//! must implement [BytesIter::is_consumed][is_consumed] correctly.
+//!
+//! This must correctly determine if there are any elements left in the iterator.
+//! If the buffer is contiguous, this can just be `index == self.len()`, but for
+//! a non-contiguous iterator it must skip any digits to advance to the element
+//! next to be returned or the iterator itself will be unsafe. **ALL** other
+//! safety invariants depend on this being implemented correctly.
+//!
+//! To see if the cursor is at the end of the buffer, use [BytesIter::is_done][is_done].
+//!
+//! Any iterators must be peekable: you must be able to read and return the next
+//! value without advancing the iterator past that point. For iterators that skip
+//! bytes, this means advancing to the next element to be returned and returning
+//! that value. Therefore, [peek_unchecked] for skip iterators must be implemented
+//! in terms of [peek]: you must peek the next element and [peek_unchecked] will
+//! merely unwrap this value. Contiguous iterators can use raw indexing instead.
+//!
+//! For examples of how to safely implement skip iterators, you can do something like:
+//!
+//! ```rust,ignore
+//! unsafe impl<_> BytesIter<_> for MyIter {
+//!     fn peek(&mut self) -> Option<u8> {
+//!         loop {
+//!             let value = self.bytes.get(self.index)?;
+//!             if value != &b'.' {
+//!                 return value;
+//!             }
+//!             self.index += 1;
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Then, [next](core::iter::Iterator::next) will be implemented in terms
+//! of [peek], incrementing the position in the cursor just after the value.
+//! The next iteration of peek will step to the correct byte to return.
+//!
+//! ```rust,ignore
+//! impl<_> Iterator for MyIter {
+//!     type Item = &'a u8;
+//!
+//!     fn next(&mut self) -> Option<Self::Item> {
+//!         let value = self.peek()?;
+//!         self.index += 1;
+//!         Some(value)
+//!     }
+//! }
+//! ```
+//!
+//! [is_done]: iterator::BytesIter::is_done
+//! [is_consumed]: iterator::BytesIter::is_consumed
+//! [peek]: iterator::BytesIter::peek
+//! [peek_unchecked]: iterator::BytesIter::peek_unchecked
 
 // We want to have the same safety guarantees as Rust core,
 // so we allow unused unsafe to clearly document safety guarantees.

--- a/lexical-util/src/noskip.rs
+++ b/lexical-util/src/noskip.rs
@@ -215,7 +215,7 @@ impl<'a, const __: u128> Bytes<'a, __> {
     }
 }
 
-impl<'a, const __: u128> Buffer<'a> for Bytes<'a, __> {
+unsafe impl<'a, const __: u128> Buffer<'a> for Bytes<'a, __> {
     const IS_CONTIGUOUS: bool = true;
 
     #[inline(always)]
@@ -276,7 +276,7 @@ impl<'a: 'b, 'b, const __: u128> BytesIterator<'a, 'b, __> {
     }
 }
 
-impl<'a: 'b, 'b, const __: u128> Buffer<'a> for BytesIterator<'a, 'b, __> {
+unsafe impl<'a: 'b, 'b, const __: u128> Buffer<'a> for BytesIterator<'a, 'b, __> {
     const IS_CONTIGUOUS: bool = Bytes::<'a, __>::IS_CONTIGUOUS;
 
     #[inline(always)]

--- a/lexical-util/src/not_feature_format.rs
+++ b/lexical-util/src/not_feature_format.rs
@@ -490,19 +490,19 @@ impl<const FORMAT: u128> NumberFormat<FORMAT> {
     /// Get the radix**2 for the significant digits.
     #[inline(always)]
     pub const fn radix2(&self) -> u32 {
-        self.radix() * self.radix()
+        self.radix().wrapping_mul(self.radix())
     }
 
     /// Get the radix**4 for the significant digits.
     #[inline(always)]
     pub const fn radix4(&self) -> u32 {
-        self.radix2() * self.radix2()
+        self.radix2().wrapping_mul(self.radix2())
     }
 
     /// Get the radix*** for the significant digits.
     #[inline(always)]
     pub const fn radix8(&self) -> u32 {
-        self.radix4() * self.radix4()
+        self.radix4().wrapping_mul(self.radix4())
     }
 
     /// The base for the exponent.

--- a/lexical-util/src/skip.rs
+++ b/lexical-util/src/skip.rs
@@ -568,7 +568,7 @@ impl<'a, const FORMAT: u128> Bytes<'a, FORMAT> {
     }
 }
 
-impl<'a, const FORMAT: u128> Buffer<'a> for Bytes<'a, FORMAT> {
+unsafe impl<'a, const FORMAT: u128> Buffer<'a> for Bytes<'a, FORMAT> {
     /// If each yielded value is adjacent in memory.
     const IS_CONTIGUOUS: bool = NumberFormat::<{ FORMAT }>::DIGIT_SEPARATOR == 0;
 
@@ -798,7 +798,7 @@ macro_rules! skip_iterator_bytesiter_base {
 /// Create impl ByteIter block for skip iterator.
 macro_rules! skip_iterator_bytesiter_impl {
     ($iterator:ident, $mask:ident, $i:ident, $l:ident, $t:ident, $c:ident) => {
-        impl<'a: 'b, 'b, const FORMAT: u128> Buffer<'a> for $iterator<'a, 'b, FORMAT> {
+        unsafe impl<'a: 'b, 'b, const FORMAT: u128> Buffer<'a> for $iterator<'a, 'b, FORMAT> {
             skip_iterator_buffer_base!(FORMAT, $mask);
         }
 
@@ -902,7 +902,7 @@ impl<'a: 'b, 'b, const FORMAT: u128> SpecialBytesIterator<'a, 'b, FORMAT> {
     is_digit_separator!(FORMAT);
 }
 
-impl<'a: 'b, 'b, const FORMAT: u128> Buffer<'a> for SpecialBytesIterator<'a, 'b, FORMAT> {
+unsafe impl<'a: 'b, 'b, const FORMAT: u128> Buffer<'a> for SpecialBytesIterator<'a, 'b, FORMAT> {
     skip_iterator_buffer_base!(FORMAT, SPECIAL_DIGIT_SEPARATOR);
 }
 

--- a/lexical-util/tests/algorithm_tests.rs
+++ b/lexical-util/tests/algorithm_tests.rs
@@ -28,28 +28,3 @@ fn ltrim_char_test() {
     assert_eq!(algorithm::ltrim_char_count(z.as_bytes(), b'1'), 1);
     assert_eq!(algorithm::ltrim_char_count(z.as_bytes(), b'5'), 0);
 }
-
-#[test]
-#[cfg(feature = "write")]
-fn rtrim_char_test() {
-    let w = "0001";
-    let x = "1010";
-    let y = "1.00";
-    let z = "1e05";
-
-    assert_eq!(algorithm::rtrim_char_count(w.as_bytes(), b'0'), 0);
-    assert_eq!(algorithm::rtrim_char_count(x.as_bytes(), b'0'), 1);
-    assert_eq!(algorithm::rtrim_char_count(x.as_bytes(), b'1'), 0);
-    assert_eq!(algorithm::rtrim_char_count(y.as_bytes(), b'0'), 2);
-    assert_eq!(algorithm::rtrim_char_count(y.as_bytes(), b'1'), 0);
-    assert_eq!(algorithm::rtrim_char_count(z.as_bytes(), b'0'), 0);
-    assert_eq!(algorithm::rtrim_char_count(z.as_bytes(), b'5'), 1);
-
-    assert_eq!(algorithm::rtrim_char_slice(w.as_bytes(), b'0').1, 0);
-    assert_eq!(algorithm::rtrim_char_slice(x.as_bytes(), b'0').1, 1);
-    assert_eq!(algorithm::rtrim_char_slice(x.as_bytes(), b'1').1, 0);
-    assert_eq!(algorithm::rtrim_char_slice(y.as_bytes(), b'0').1, 2);
-    assert_eq!(algorithm::rtrim_char_slice(y.as_bytes(), b'1').1, 0);
-    assert_eq!(algorithm::rtrim_char_slice(z.as_bytes(), b'0').1, 0);
-    assert_eq!(algorithm::rtrim_char_slice(z.as_bytes(), b'5').1, 1);
-}

--- a/lexical-util/tests/digit_tests.rs
+++ b/lexical-util/tests/digit_tests.rs
@@ -98,7 +98,7 @@ fn char_is_digit_const_test() {
 #[cfg(feature = "write")]
 fn digit_to_char(digit: u32, radix: u32, expected: u8) {
     assert_eq!(digit::digit_to_char_const(digit, radix), expected);
-    assert_eq!(unsafe { digit::digit_to_char(digit) }, expected);
+    assert_eq!(digit::digit_to_char(digit), expected);
 }
 
 #[test]

--- a/lexical-write-integer/src/compact.rs
+++ b/lexical-write-integer/src/compact.rs
@@ -9,66 +9,51 @@
 use core::mem;
 
 use lexical_util::algorithm::copy_to_dst;
-use lexical_util::assert::debug_assert_radix;
+use lexical_util::buffer::slice_assume_init_mut;
+use lexical_util::constants::FormattedSize;
 use lexical_util::digit::digit_to_char;
 use lexical_util::num::{AsCast, UnsignedInteger};
 
-/// Write integral digits to buffer.
-///
-/// This algorithm does not use any pre-computed tables, reducing code
-/// size at the cost of faster performance.
-///
-/// # Safety
-///
-/// This is safe as long as the buffer is large enough to hold `T::MAX`
-/// digits in radix `N`.
-pub unsafe fn write_digits<T: UnsignedInteger>(
-    mut value: T,
-    radix: u32,
-    buffer: &mut [u8],
-    mut index: usize,
-) -> usize {
-    debug_assert_radix(radix);
-
-    // SAFETY: All of these are safe for the buffer writes as long as
-    // the buffer is large enough to hold `T::FORMATTED_SIZE` digits,
-    // and `radix <= 36`.
-
-    // Decode all but the last digit.
-    let radix = T::from_u32(radix);
-    while value >= radix {
-        let r = value % radix;
-        value /= radix;
-        index -= 1;
-        unsafe { index_unchecked_mut!(buffer[index]) = digit_to_char(u32::as_cast(r)) };
-    }
-
-    // Decode last digit.
-    let r = value % radix;
-    index -= 1;
-    unsafe { index_unchecked_mut!(buffer[index]) = digit_to_char(u32::as_cast(r)) };
-
-    index
-}
-
 /// Write integer to string.
-pub trait Compact: UnsignedInteger {
-    /// # Safety
+pub trait Compact: UnsignedInteger + FormattedSize {
+    /// Write our integer to string without optimizations.
     ///
-    /// Safe as long as buffer is at least `FORMATTED_SIZE` elements long,
-    /// (or `FORMATTED_SIZE_DECIMAL` for decimal), and the radix is valid.
-    unsafe fn compact(self, radix: u32, buffer: &mut [u8]) -> usize {
+    /// This iterates over the buffer in reverse, and ensures that at least
+    /// 128 elements exist in the temporary buffer. This ensures that the digits
+    /// can never overflow, even in base 2. The buffer then must be able to hold
+    /// at least 128 digits as well, after subslicing the data. This guarantee
+    /// is likely already made.
+    fn compact(self, radix: u32, buffer: &mut [u8]) -> usize {
+        // NOTE: We do not have to validate the buffer length because `copy_to_dst` is safe.
+        assert!(Self::BITS <= 128);
+        let mut digits: [mem::MaybeUninit<u8>; 128] = [mem::MaybeUninit::uninit(); 128];
+        let mut index = digits.len();
+
         // SAFETY: safe as long as buffer is large enough to hold the max value.
         // We never read unwritten values, and we never assume the data is initialized.
         // Need at least 128-bits, at least as many as the bits in the current type.
-        debug_assert!(Self::BITS <= 128);
-        let mut digits: mem::MaybeUninit<[u8; 128]> = mem::MaybeUninit::uninit();
-        unsafe {
-            let digits = &mut *digits.as_mut_ptr();
-            let length = digits.len();
-            let index = write_digits(self, radix, digits, length);
-            copy_to_dst(buffer, &mut index_unchecked_mut!(digits[index..]))
-        }
+        // Since we make our safety variants inside, this is always safe.
+        let inititalized = unsafe {
+            // Decode all but the last digit.
+            let radix = Self::from_u32(radix);
+            let mut value = self;
+            while value >= radix {
+                let r = value % radix;
+                value /= radix;
+                index -= 1;
+                digits.get_unchecked_mut(index).write(digit_to_char(u32::as_cast(r)));
+            }
+
+            // Decode last digit.
+            let r = value % radix;
+            index -= 1;
+            digits.get_unchecked_mut(index).write(digit_to_char(u32::as_cast(r)));
+            let uninit = digits.get_unchecked_mut(index..);
+            // SAFETY: All these values have been initialized, since we know
+            // we've only written from `index..len()`
+            slice_assume_init_mut(uninit)
+        };
+        copy_to_dst(buffer, inititalized)
     }
 }
 

--- a/lexical-write-integer/src/decimal.rs
+++ b/lexical-write-integer/src/decimal.rs
@@ -234,7 +234,7 @@ pub trait Decimal: DigitCount {
     ///
     /// [`FORMATTED_SIZE`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE
     /// [`FORMATTED_SIZE_DECIMAL`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE_DECIMAL
-    unsafe fn decimal(self, buffer: &mut [u8]) -> usize;
+    fn decimal(self, buffer: &mut [u8]) -> usize;
 }
 
 // Don't implement decimal for small types, where we could have an overflow.
@@ -242,7 +242,7 @@ macro_rules! decimal_unimpl {
     ($($t:ty)*) => ($(
         impl Decimal for $t {
             #[inline(always)]
-            unsafe fn decimal(self, _: &mut [u8]) -> usize {
+            fn decimal(self, _: &mut [u8]) -> usize {
                 // Forces a hard error if we have a logic error in our code.
                 unimplemented!()
             }
@@ -257,10 +257,10 @@ macro_rules! decimal_impl {
     ($($t:ty)*) => ($(
         impl Decimal for $t {
             #[inline(always)]
-            unsafe fn decimal(self, buffer: &mut [u8]) -> usize {
+            fn decimal(self, buffer: &mut [u8]) -> usize {
                 // SAFETY: safe as long as buffer is large enough to hold the max value.
                 let count = self.digit_count();
-                debug_assert!(count <= buffer.len());
+                assert!(count <= buffer.len());
                 unsafe {
                     algorithm(self, 10, &DIGIT_TO_BASE10_SQUARED, &mut buffer[..count]);
                     count
@@ -274,10 +274,10 @@ decimal_impl! { u32 u64 }
 
 impl Decimal for u128 {
     #[inline(always)]
-    unsafe fn decimal(self, buffer: &mut [u8]) -> usize {
+    fn decimal(self, buffer: &mut [u8]) -> usize {
         // SAFETY: safe as long as buffer is large enough to hold the max value.
         let count = self.digit_count();
-        debug_assert!(count <= buffer.len());
+        assert!(count <= buffer.len());
         unsafe {
             algorithm_u128::<{ STANDARD }, { RADIX }, { RADIX_SHIFT }>(
                 self,

--- a/lexical-write-integer/src/radix.rs
+++ b/lexical-write-integer/src/radix.rs
@@ -14,11 +14,8 @@
 
 use crate::algorithm::{algorithm, algorithm_u128};
 use crate::table::get_table;
-use core::mem;
 use lexical_util::algorithm::copy_to_dst;
-use lexical_util::assert::assert_buffer;
 use lexical_util::format;
-use lexical_util::format::NumberFormat;
 use lexical_util::num::{Integer, UnsignedInteger};
 
 /// Write integer to radix string.
@@ -58,22 +55,12 @@ macro_rules! radix_impl {
                 buffer: &mut [u8]
             ) -> usize {
                 debug_assert!(<Self as Integer>::BITS <= 64);
-                assert_buffer::<$t>(NumberFormat::<{ FORMAT }>::RADIX, buffer.len());
                 let radix = format::radix_from_flags(FORMAT, MASK, SHIFT);
                 let table = get_table::<FORMAT, MASK, SHIFT>();
-
-                let mut digits: mem::MaybeUninit<[u8; 64]> = mem::MaybeUninit::uninit();
-                // # Safety
-                //
-                // Safe as long as buffer is large enough to hold the max value, which we validate.
-                // above. We never read unwritten values, and we never assume the data is initialized.
-                // Need at least $T::BITS-bits, at least as many as the bits in the current type. Ensuring
-                // no uninitialized memory is read is verified by miri.
-                unsafe {
-                    let digits = &mut *digits.as_mut_ptr();
-                    let index = algorithm(self, radix, table, digits);
-                    copy_to_dst(buffer, &mut index_unchecked_mut!(digits[index..]))
-                }
+                let mut digits: [u8; 64] = [0u8; 64];
+                // SAFETY: Safe since 64 bytes is always enough to hold the digits of a <= 64 bit integer.
+                let index = unsafe { algorithm(self, radix, table, &mut digits) };
+                copy_to_dst(buffer, &mut digits[index..])
             }
         }
     )*);
@@ -87,20 +74,10 @@ impl Radix for u128 {
         self,
         buffer: &mut [u8],
     ) -> usize {
-        assert_buffer::<u128>(NumberFormat::<{ FORMAT }>::RADIX, buffer.len());
         let table = get_table::<FORMAT, MASK, SHIFT>();
-
-        let mut digits: mem::MaybeUninit<[u8; 128]> = mem::MaybeUninit::uninit();
-        // # Safety
-        //
-        // Safe as long as buffer is large enough to hold the max value, which we validate.
-        // above. We never read unwritten values, and we never assume the data is initialized.
-        // Need at least 128-bits, at least as many as the bits in the current type. Ensuring
-        // no uninitialized memory is read is verified by miri.
-        unsafe {
-            let digits = &mut *digits.as_mut_ptr();
-            let index = algorithm_u128::<FORMAT, MASK, SHIFT>(self, table, digits);
-            copy_to_dst(buffer, &mut index_unchecked_mut!(digits[index..]))
-        }
+        let mut digits: [u8; 128] = [0u8; 128];
+        // SAFETY: Safe since 128 bytes is always enough to hold the digits of a 128 bit integer.
+        let index = unsafe { algorithm_u128::<FORMAT, MASK, SHIFT>(self, table, &mut digits) };
+        copy_to_dst(buffer, &mut digits[index..])
     }
 }

--- a/lexical-write-integer/src/write.rs
+++ b/lexical-write-integer/src/write.rs
@@ -15,18 +15,13 @@ use lexical_util::format;
 macro_rules! write_mantissa {
     ($($t:tt)+) => (
         /// Internal implementation to write significant digits for float writers.
-        ///
-        /// # Safety
-        ///
-        /// Safe as long as the buffer can hold `FORMATTED_SIZE` elements.
         #[doc(hidden)]
         #[inline(always)]
-        unsafe fn write_mantissa<U, const FORMAT: u128>(self, buffer: &mut [u8]) -> usize
+        fn write_mantissa<U, const FORMAT: u128>(self, buffer: &mut [u8]) -> usize
         where
             U: $($t)+,
         {
-            // SAFETY: safe as long as the buffer can hold `FORMATTED_SIZE` elements.
-            unsafe { self.write_integer::<U, FORMAT, { format::RADIX }, { format::RADIX_SHIFT }>(buffer) }
+            self.write_integer::<U, FORMAT, { format::RADIX }, { format::RADIX_SHIFT }>(buffer)
         }
     )
 }
@@ -35,18 +30,13 @@ macro_rules! write_mantissa {
 macro_rules! write_exponent {
     ($($t:tt)+) => (
         /// Internal implementation to write exponent digits for float writers.
-        ///
-        /// # Safety
-        ///
-        /// Safe as long as the buffer can hold `FORMATTED_SIZE` elements.
         #[doc(hidden)]
         #[inline(always)]
-        unsafe fn write_exponent<U, const FORMAT: u128>(self, buffer: &mut [u8]) -> usize
+        fn write_exponent<U, const FORMAT: u128>(self, buffer: &mut [u8]) -> usize
         where
             U: $($t)+,
         {
-            // SAFETY: safe as long as the buffer can hold `FORMATTED_SIZE` elements.
-            unsafe { self.write_integer::<U, FORMAT, { format::EXPONENT_RADIX }, { format::EXPONENT_RADIX_SHIFT }>(buffer) }
+            self.write_integer::<U, FORMAT, { format::EXPONENT_RADIX }, { format::EXPONENT_RADIX_SHIFT }>(buffer)
         }
     )
 }
@@ -60,14 +50,9 @@ pub trait WriteInteger: Compact {
     ///
     /// `self` must be non-negative and unsigned.
     ///
-    /// # Safety
-    ///
-    /// Safe as long as the buffer can hold [`FORMATTED_SIZE`] elements
-    /// (or [`FORMATTED_SIZE_DECIMAL`] for decimal).
-    ///
     /// [`FORMATTED_SIZE`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE
     /// [`FORMATTED_SIZE_DECIMAL`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE_DECIMAL
-    unsafe fn write_integer<U, const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
+    fn write_integer<U, const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
         self,
         buffer: &mut [u8],
     ) -> usize
@@ -76,7 +61,7 @@ pub trait WriteInteger: Compact {
     {
         let value = U::as_cast(self);
         let radix = format::radix_from_flags(FORMAT, MASK, SHIFT);
-        unsafe { value.compact(radix, buffer) }
+        value.compact(radix, buffer)
     }
 
     write_mantissa!(Compact);
@@ -92,13 +77,9 @@ pub trait WriteInteger: Decimal {
     ///
     /// `self` must be non-negative and unsigned.
     ///
-    /// # Safety
-    ///
-    /// Safe as long as the buffer can hold [`FORMATTED_SIZE_DECIMAL`] elements.
-    ///
     /// [`FORMATTED_SIZE_DECIMAL`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE_DECIMAL
     #[inline(always)]
-    unsafe fn write_integer<U, const __: u128, const ___: u128, const ____: i32>(
+    fn write_integer<U, const __: u128, const ___: u128, const ____: i32>(
         self,
         buffer: &mut [u8],
     ) -> usize
@@ -106,7 +87,7 @@ pub trait WriteInteger: Decimal {
         U: Decimal,
     {
         let value = U::as_cast(self);
-        unsafe { value.decimal(buffer) }
+        value.decimal(buffer)
     }
 
     write_mantissa!(Decimal);
@@ -122,15 +103,10 @@ pub trait WriteInteger: Decimal + Radix {
     ///
     /// `self` must be non-negative and unsigned.
     ///
-    /// # Safety
-    ///
-    /// Safe as long as the buffer can hold [`FORMATTED_SIZE`] elements
-    /// (or [`FORMATTED_SIZE_DECIMAL`] for decimal).
-    ///
     /// [`FORMATTED_SIZE`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE
     /// [`FORMATTED_SIZE_DECIMAL`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE_DECIMAL
     #[inline(always)]
-    unsafe fn write_integer<U, const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
+    fn write_integer<U, const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
         self,
         buffer: &mut [u8],
     ) -> usize
@@ -139,9 +115,9 @@ pub trait WriteInteger: Decimal + Radix {
     {
         let value = U::as_cast(self);
         if format::radix_from_flags(FORMAT, MASK, SHIFT) == 10 {
-            unsafe { value.decimal(buffer) }
+            value.decimal(buffer)
         } else {
-            unsafe { value.radix::<FORMAT, MASK, SHIFT>(buffer) }
+            value.radix::<FORMAT, MASK, SHIFT>(buffer)
         }
     }
 

--- a/lexical-write-integer/tests/api_tests.rs
+++ b/lexical-write-integer/tests/api_tests.rs
@@ -3,7 +3,6 @@ mod util;
 
 use core::fmt::Debug;
 use core::str::{from_utf8_unchecked, FromStr};
-use lexical_util::constants::FormattedSize;
 #[cfg(feature = "radix")]
 use lexical_util::constants::BUFFER_SIZE;
 #[cfg(feature = "format")]
@@ -1410,83 +1409,89 @@ proptest! {
 #[test]
 #[should_panic]
 fn i8_buffer_test() {
-    let mut buffer = [b'\x00'; i8::FORMATTED_SIZE_DECIMAL - 1];
-    12i8.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 3];
+    (-123i8).to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn i16_buffer_test() {
-    let mut buffer = [b'\x00'; i16::FORMATTED_SIZE_DECIMAL - 1];
-    12i16.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 4];
+    (-1234i16).to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn i32_buffer_test() {
-    let mut buffer = [b'\x00'; i32::FORMATTED_SIZE_DECIMAL - 1];
-    12i32.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 6];
+    (-123456i32).to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn i64_buffer_test() {
-    let mut buffer = [b'\x00'; i64::FORMATTED_SIZE_DECIMAL - 1];
-    12i64.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 7];
+    (-1234567i64).to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn i128_buffer_test() {
-    let mut buffer = [b'\x00'; i128::FORMATTED_SIZE_DECIMAL - 1];
-    12i128.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 9];
+    (-123456789i128).to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn isize_buffer_test() {
-    let mut buffer = [b'\x00'; isize::FORMATTED_SIZE_DECIMAL - 1];
-    12isize.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 6];
+    (-123456isize).to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn u8_buffer_test() {
-    let mut buffer = [b'\x00'; u8::FORMATTED_SIZE_DECIMAL - 1];
-    12i8.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 2];
+    125u8.to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn u16_buffer_test() {
-    let mut buffer = [b'\x00'; u16::FORMATTED_SIZE_DECIMAL - 1];
+    let mut buffer = [b'\x00'; 1];
     12i16.to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn u32_buffer_test() {
-    let mut buffer = [b'\x00'; u32::FORMATTED_SIZE_DECIMAL - 1];
-    12i32.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 5];
+    123456i32.to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn u64_buffer_test() {
-    let mut buffer = [b'\x00'; u64::FORMATTED_SIZE_DECIMAL - 1];
-    12i64.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 5];
+    123456i64.to_lexical(&mut buffer);
+}
+
+#[test]
+fn u64_buffer_no_panic_test() {
+    let mut buffer = [b'\x00'; 6];
+    12345i64.to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn u128_buffer_test() {
-    let mut buffer = [b'\x00'; u128::FORMATTED_SIZE_DECIMAL - 1];
-    12i128.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 8];
+    123456789i128.to_lexical(&mut buffer);
 }
 
 #[test]
 #[should_panic]
 fn usize_buffer_test() {
-    let mut buffer = [b'\x00'; usize::FORMATTED_SIZE_DECIMAL - 1];
-    12usize.to_lexical(&mut buffer);
+    let mut buffer = [b'\x00'; 5];
+    123456usize.to_lexical(&mut buffer);
 }

--- a/lexical-write-integer/tests/decimal_tests.rs
+++ b/lexical-write-integer/tests/decimal_tests.rs
@@ -69,340 +69,334 @@ fn u128_digit_count_test() {
 #[test]
 fn u32toa_test() {
     let mut buffer = [b'\x00'; 16];
-    unsafe {
-        assert_eq!(5u32.decimal(&mut buffer), 1);
-        assert_eq!(&buffer[..1], b"5");
+    assert_eq!(5u32.decimal(&mut buffer), 1);
+    assert_eq!(&buffer[..1], b"5");
 
-        assert_eq!(11u32.decimal(&mut buffer), 2);
-        assert_eq!(&buffer[..2], b"11");
+    assert_eq!(11u32.decimal(&mut buffer), 2);
+    assert_eq!(&buffer[..2], b"11");
 
-        assert_eq!(99u32.decimal(&mut buffer), 2);
-        assert_eq!(&buffer[..2], b"99");
+    assert_eq!(99u32.decimal(&mut buffer), 2);
+    assert_eq!(&buffer[..2], b"99");
 
-        assert_eq!(101u32.decimal(&mut buffer), 3);
-        assert_eq!(&buffer[..3], b"101");
+    assert_eq!(101u32.decimal(&mut buffer), 3);
+    assert_eq!(&buffer[..3], b"101");
 
-        assert_eq!(999u32.decimal(&mut buffer), 3);
-        assert_eq!(&buffer[..3], b"999");
+    assert_eq!(999u32.decimal(&mut buffer), 3);
+    assert_eq!(&buffer[..3], b"999");
 
-        assert_eq!(1001u32.decimal(&mut buffer), 4);
-        assert_eq!(&buffer[..4], b"1001");
+    assert_eq!(1001u32.decimal(&mut buffer), 4);
+    assert_eq!(&buffer[..4], b"1001");
 
-        assert_eq!(9999u32.decimal(&mut buffer), 4);
-        assert_eq!(&buffer[..4], b"9999");
+    assert_eq!(9999u32.decimal(&mut buffer), 4);
+    assert_eq!(&buffer[..4], b"9999");
 
-        assert_eq!(10001u32.decimal(&mut buffer), 5);
-        assert_eq!(&buffer[..5], b"10001");
+    assert_eq!(10001u32.decimal(&mut buffer), 5);
+    assert_eq!(&buffer[..5], b"10001");
 
-        assert_eq!(65535u32.decimal(&mut buffer), 5);
-        assert_eq!(&buffer[..5], b"65535");
+    assert_eq!(65535u32.decimal(&mut buffer), 5);
+    assert_eq!(&buffer[..5], b"65535");
 
-        assert_eq!(99999u32.decimal(&mut buffer), 5);
-        assert_eq!(&buffer[..5], b"99999");
+    assert_eq!(99999u32.decimal(&mut buffer), 5);
+    assert_eq!(&buffer[..5], b"99999");
 
-        assert_eq!(100001u32.decimal(&mut buffer), 6);
-        assert_eq!(&buffer[..6], b"100001");
+    assert_eq!(100001u32.decimal(&mut buffer), 6);
+    assert_eq!(&buffer[..6], b"100001");
 
-        assert_eq!(999999u32.decimal(&mut buffer), 6);
-        assert_eq!(&buffer[..6], b"999999");
+    assert_eq!(999999u32.decimal(&mut buffer), 6);
+    assert_eq!(&buffer[..6], b"999999");
 
-        assert_eq!(1000001u32.decimal(&mut buffer), 7);
-        assert_eq!(&buffer[..7], b"1000001");
+    assert_eq!(1000001u32.decimal(&mut buffer), 7);
+    assert_eq!(&buffer[..7], b"1000001");
 
-        assert_eq!(9999999u32.decimal(&mut buffer), 7);
-        assert_eq!(&buffer[..7], b"9999999");
+    assert_eq!(9999999u32.decimal(&mut buffer), 7);
+    assert_eq!(&buffer[..7], b"9999999");
 
-        assert_eq!(10000001u32.decimal(&mut buffer), 8);
-        assert_eq!(&buffer[..8], b"10000001");
+    assert_eq!(10000001u32.decimal(&mut buffer), 8);
+    assert_eq!(&buffer[..8], b"10000001");
 
-        assert_eq!(99999999u32.decimal(&mut buffer), 8);
-        assert_eq!(&buffer[..8], b"99999999");
+    assert_eq!(99999999u32.decimal(&mut buffer), 8);
+    assert_eq!(&buffer[..8], b"99999999");
 
-        assert_eq!(100000001u32.decimal(&mut buffer), 9);
-        assert_eq!(&buffer[..9], b"100000001");
+    assert_eq!(100000001u32.decimal(&mut buffer), 9);
+    assert_eq!(&buffer[..9], b"100000001");
 
-        assert_eq!(999999999u32.decimal(&mut buffer), 9);
-        assert_eq!(&buffer[..9], b"999999999");
+    assert_eq!(999999999u32.decimal(&mut buffer), 9);
+    assert_eq!(&buffer[..9], b"999999999");
 
-        assert_eq!(1000000001u32.decimal(&mut buffer), 10);
-        assert_eq!(&buffer[..10], b"1000000001");
+    assert_eq!(1000000001u32.decimal(&mut buffer), 10);
+    assert_eq!(&buffer[..10], b"1000000001");
 
-        assert_eq!(4294967295u32.decimal(&mut buffer), 10);
-        assert_eq!(&buffer[..10], b"4294967295");
-    }
+    assert_eq!(4294967295u32.decimal(&mut buffer), 10);
+    assert_eq!(&buffer[..10], b"4294967295");
 }
 
 #[test]
 fn u64toa_test() {
     let mut buffer = [b'\x00'; 32];
-    unsafe {
-        assert_eq!(5u64.decimal(&mut buffer), 1);
-        assert_eq!(&buffer[..1], b"5");
+    assert_eq!(5u64.decimal(&mut buffer), 1);
+    assert_eq!(&buffer[..1], b"5");
 
-        assert_eq!(11u64.decimal(&mut buffer), 2);
-        assert_eq!(&buffer[..2], b"11");
+    assert_eq!(11u64.decimal(&mut buffer), 2);
+    assert_eq!(&buffer[..2], b"11");
 
-        assert_eq!(99u64.decimal(&mut buffer), 2);
-        assert_eq!(&buffer[..2], b"99");
+    assert_eq!(99u64.decimal(&mut buffer), 2);
+    assert_eq!(&buffer[..2], b"99");
 
-        assert_eq!(101u64.decimal(&mut buffer), 3);
-        assert_eq!(&buffer[..3], b"101");
+    assert_eq!(101u64.decimal(&mut buffer), 3);
+    assert_eq!(&buffer[..3], b"101");
 
-        assert_eq!(999u64.decimal(&mut buffer), 3);
-        assert_eq!(&buffer[..3], b"999");
+    assert_eq!(999u64.decimal(&mut buffer), 3);
+    assert_eq!(&buffer[..3], b"999");
 
-        assert_eq!(1001u64.decimal(&mut buffer), 4);
-        assert_eq!(&buffer[..4], b"1001");
+    assert_eq!(1001u64.decimal(&mut buffer), 4);
+    assert_eq!(&buffer[..4], b"1001");
 
-        assert_eq!(9999u64.decimal(&mut buffer), 4);
-        assert_eq!(&buffer[..4], b"9999");
+    assert_eq!(9999u64.decimal(&mut buffer), 4);
+    assert_eq!(&buffer[..4], b"9999");
 
-        assert_eq!(10001u64.decimal(&mut buffer), 5);
-        assert_eq!(&buffer[..5], b"10001");
+    assert_eq!(10001u64.decimal(&mut buffer), 5);
+    assert_eq!(&buffer[..5], b"10001");
 
-        assert_eq!(65535u64.decimal(&mut buffer), 5);
-        assert_eq!(&buffer[..5], b"65535");
+    assert_eq!(65535u64.decimal(&mut buffer), 5);
+    assert_eq!(&buffer[..5], b"65535");
 
-        assert_eq!(99999u64.decimal(&mut buffer), 5);
-        assert_eq!(&buffer[..5], b"99999");
+    assert_eq!(99999u64.decimal(&mut buffer), 5);
+    assert_eq!(&buffer[..5], b"99999");
 
-        assert_eq!(100001u64.decimal(&mut buffer), 6);
-        assert_eq!(&buffer[..6], b"100001");
+    assert_eq!(100001u64.decimal(&mut buffer), 6);
+    assert_eq!(&buffer[..6], b"100001");
 
-        assert_eq!(999999u64.decimal(&mut buffer), 6);
-        assert_eq!(&buffer[..6], b"999999");
+    assert_eq!(999999u64.decimal(&mut buffer), 6);
+    assert_eq!(&buffer[..6], b"999999");
 
-        assert_eq!(1000001u64.decimal(&mut buffer), 7);
-        assert_eq!(&buffer[..7], b"1000001");
+    assert_eq!(1000001u64.decimal(&mut buffer), 7);
+    assert_eq!(&buffer[..7], b"1000001");
 
-        assert_eq!(9999999u64.decimal(&mut buffer), 7);
-        assert_eq!(&buffer[..7], b"9999999");
+    assert_eq!(9999999u64.decimal(&mut buffer), 7);
+    assert_eq!(&buffer[..7], b"9999999");
 
-        assert_eq!(10000001u64.decimal(&mut buffer), 8);
-        assert_eq!(&buffer[..8], b"10000001");
+    assert_eq!(10000001u64.decimal(&mut buffer), 8);
+    assert_eq!(&buffer[..8], b"10000001");
 
-        assert_eq!(99999999u64.decimal(&mut buffer), 8);
-        assert_eq!(&buffer[..8], b"99999999");
+    assert_eq!(99999999u64.decimal(&mut buffer), 8);
+    assert_eq!(&buffer[..8], b"99999999");
 
-        assert_eq!(100000001u64.decimal(&mut buffer), 9);
-        assert_eq!(&buffer[..9], b"100000001");
+    assert_eq!(100000001u64.decimal(&mut buffer), 9);
+    assert_eq!(&buffer[..9], b"100000001");
 
-        assert_eq!(999999999u64.decimal(&mut buffer), 9);
-        assert_eq!(&buffer[..9], b"999999999");
+    assert_eq!(999999999u64.decimal(&mut buffer), 9);
+    assert_eq!(&buffer[..9], b"999999999");
 
-        assert_eq!(1000000001u64.decimal(&mut buffer), 10);
-        assert_eq!(&buffer[..10], b"1000000001");
+    assert_eq!(1000000001u64.decimal(&mut buffer), 10);
+    assert_eq!(&buffer[..10], b"1000000001");
 
-        assert_eq!(9999999999u64.decimal(&mut buffer), 10);
-        assert_eq!(&buffer[..10], b"9999999999");
+    assert_eq!(9999999999u64.decimal(&mut buffer), 10);
+    assert_eq!(&buffer[..10], b"9999999999");
 
-        assert_eq!(10000000001u64.decimal(&mut buffer), 11);
-        assert_eq!(&buffer[..11], b"10000000001");
+    assert_eq!(10000000001u64.decimal(&mut buffer), 11);
+    assert_eq!(&buffer[..11], b"10000000001");
 
-        assert_eq!(99999999999u64.decimal(&mut buffer), 11);
-        assert_eq!(&buffer[..11], b"99999999999");
+    assert_eq!(99999999999u64.decimal(&mut buffer), 11);
+    assert_eq!(&buffer[..11], b"99999999999");
 
-        assert_eq!(100000000001u64.decimal(&mut buffer), 12);
-        assert_eq!(&buffer[..12], b"100000000001");
+    assert_eq!(100000000001u64.decimal(&mut buffer), 12);
+    assert_eq!(&buffer[..12], b"100000000001");
 
-        assert_eq!(999999999999u64.decimal(&mut buffer), 12);
-        assert_eq!(&buffer[..12], b"999999999999");
+    assert_eq!(999999999999u64.decimal(&mut buffer), 12);
+    assert_eq!(&buffer[..12], b"999999999999");
 
-        assert_eq!(1000000000001u64.decimal(&mut buffer), 13);
-        assert_eq!(&buffer[..13], b"1000000000001");
+    assert_eq!(1000000000001u64.decimal(&mut buffer), 13);
+    assert_eq!(&buffer[..13], b"1000000000001");
 
-        assert_eq!(9999999999999u64.decimal(&mut buffer), 13);
-        assert_eq!(&buffer[..13], b"9999999999999");
+    assert_eq!(9999999999999u64.decimal(&mut buffer), 13);
+    assert_eq!(&buffer[..13], b"9999999999999");
 
-        assert_eq!(10000000000001u64.decimal(&mut buffer), 14);
-        assert_eq!(&buffer[..14], b"10000000000001");
+    assert_eq!(10000000000001u64.decimal(&mut buffer), 14);
+    assert_eq!(&buffer[..14], b"10000000000001");
 
-        assert_eq!(99999999999999u64.decimal(&mut buffer), 14);
-        assert_eq!(&buffer[..14], b"99999999999999");
+    assert_eq!(99999999999999u64.decimal(&mut buffer), 14);
+    assert_eq!(&buffer[..14], b"99999999999999");
 
-        assert_eq!(100000000000001u64.decimal(&mut buffer), 15);
-        assert_eq!(&buffer[..15], b"100000000000001");
+    assert_eq!(100000000000001u64.decimal(&mut buffer), 15);
+    assert_eq!(&buffer[..15], b"100000000000001");
 
-        assert_eq!(999999999999999u64.decimal(&mut buffer), 15);
-        assert_eq!(&buffer[..15], b"999999999999999");
+    assert_eq!(999999999999999u64.decimal(&mut buffer), 15);
+    assert_eq!(&buffer[..15], b"999999999999999");
 
-        assert_eq!(1000000000000001u64.decimal(&mut buffer), 16);
-        assert_eq!(&buffer[..16], b"1000000000000001");
+    assert_eq!(1000000000000001u64.decimal(&mut buffer), 16);
+    assert_eq!(&buffer[..16], b"1000000000000001");
 
-        assert_eq!(9999999999999999u64.decimal(&mut buffer), 16);
-        assert_eq!(&buffer[..16], b"9999999999999999");
+    assert_eq!(9999999999999999u64.decimal(&mut buffer), 16);
+    assert_eq!(&buffer[..16], b"9999999999999999");
 
-        assert_eq!(10000000000000001u64.decimal(&mut buffer), 17);
-        assert_eq!(&buffer[..17], b"10000000000000001");
+    assert_eq!(10000000000000001u64.decimal(&mut buffer), 17);
+    assert_eq!(&buffer[..17], b"10000000000000001");
 
-        assert_eq!(99999999999999999u64.decimal(&mut buffer), 17);
-        assert_eq!(&buffer[..17], b"99999999999999999");
+    assert_eq!(99999999999999999u64.decimal(&mut buffer), 17);
+    assert_eq!(&buffer[..17], b"99999999999999999");
 
-        assert_eq!(100000000000000001u64.decimal(&mut buffer), 18);
-        assert_eq!(&buffer[..18], b"100000000000000001");
+    assert_eq!(100000000000000001u64.decimal(&mut buffer), 18);
+    assert_eq!(&buffer[..18], b"100000000000000001");
 
-        assert_eq!(999999999999999999u64.decimal(&mut buffer), 18);
-        assert_eq!(&buffer[..18], b"999999999999999999");
+    assert_eq!(999999999999999999u64.decimal(&mut buffer), 18);
+    assert_eq!(&buffer[..18], b"999999999999999999");
 
-        assert_eq!(1000000000000000001u64.decimal(&mut buffer), 19);
-        assert_eq!(&buffer[..19], b"1000000000000000001");
+    assert_eq!(1000000000000000001u64.decimal(&mut buffer), 19);
+    assert_eq!(&buffer[..19], b"1000000000000000001");
 
-        assert_eq!(9999999999999999999u64.decimal(&mut buffer), 19);
-        assert_eq!(&buffer[..19], b"9999999999999999999");
+    assert_eq!(9999999999999999999u64.decimal(&mut buffer), 19);
+    assert_eq!(&buffer[..19], b"9999999999999999999");
 
-        assert_eq!(10000000000000000001u64.decimal(&mut buffer), 20);
-        assert_eq!(&buffer[..20], b"10000000000000000001");
+    assert_eq!(10000000000000000001u64.decimal(&mut buffer), 20);
+    assert_eq!(&buffer[..20], b"10000000000000000001");
 
-        assert_eq!(18446744073709551615u64.decimal(&mut buffer), 20);
-        assert_eq!(&buffer[..20], b"18446744073709551615");
-    }
+    assert_eq!(18446744073709551615u64.decimal(&mut buffer), 20);
+    assert_eq!(&buffer[..20], b"18446744073709551615");
 }
 
 #[test]
 fn u128toa_test() {
     let mut buffer = [b'\x00'; 48];
-    unsafe {
-        assert_eq!(5u128.decimal(&mut buffer), 1);
-        assert_eq!(&buffer[..1], b"5");
+    assert_eq!(5u128.decimal(&mut buffer), 1);
+    assert_eq!(&buffer[..1], b"5");
 
-        assert_eq!(11u128.decimal(&mut buffer), 2);
-        assert_eq!(&buffer[..2], b"11");
+    assert_eq!(11u128.decimal(&mut buffer), 2);
+    assert_eq!(&buffer[..2], b"11");
 
-        assert_eq!(99u128.decimal(&mut buffer), 2);
-        assert_eq!(&buffer[..2], b"99");
+    assert_eq!(99u128.decimal(&mut buffer), 2);
+    assert_eq!(&buffer[..2], b"99");
 
-        assert_eq!(101u128.decimal(&mut buffer), 3);
-        assert_eq!(&buffer[..3], b"101");
+    assert_eq!(101u128.decimal(&mut buffer), 3);
+    assert_eq!(&buffer[..3], b"101");
 
-        assert_eq!(999u128.decimal(&mut buffer), 3);
-        assert_eq!(&buffer[..3], b"999");
+    assert_eq!(999u128.decimal(&mut buffer), 3);
+    assert_eq!(&buffer[..3], b"999");
 
-        assert_eq!(1001u128.decimal(&mut buffer), 4);
-        assert_eq!(&buffer[..4], b"1001");
+    assert_eq!(1001u128.decimal(&mut buffer), 4);
+    assert_eq!(&buffer[..4], b"1001");
 
-        assert_eq!(9999u128.decimal(&mut buffer), 4);
-        assert_eq!(&buffer[..4], b"9999");
+    assert_eq!(9999u128.decimal(&mut buffer), 4);
+    assert_eq!(&buffer[..4], b"9999");
 
-        assert_eq!(10001u128.decimal(&mut buffer), 5);
-        assert_eq!(&buffer[..5], b"10001");
+    assert_eq!(10001u128.decimal(&mut buffer), 5);
+    assert_eq!(&buffer[..5], b"10001");
 
-        assert_eq!(65535u128.decimal(&mut buffer), 5);
-        assert_eq!(&buffer[..5], b"65535");
+    assert_eq!(65535u128.decimal(&mut buffer), 5);
+    assert_eq!(&buffer[..5], b"65535");
 
-        assert_eq!(99999u128.decimal(&mut buffer), 5);
-        assert_eq!(&buffer[..5], b"99999");
+    assert_eq!(99999u128.decimal(&mut buffer), 5);
+    assert_eq!(&buffer[..5], b"99999");
 
-        assert_eq!(100001u128.decimal(&mut buffer), 6);
-        assert_eq!(&buffer[..6], b"100001");
+    assert_eq!(100001u128.decimal(&mut buffer), 6);
+    assert_eq!(&buffer[..6], b"100001");
 
-        assert_eq!(999999u128.decimal(&mut buffer), 6);
-        assert_eq!(&buffer[..6], b"999999");
+    assert_eq!(999999u128.decimal(&mut buffer), 6);
+    assert_eq!(&buffer[..6], b"999999");
 
-        assert_eq!(1000001u128.decimal(&mut buffer), 7);
-        assert_eq!(&buffer[..7], b"1000001");
+    assert_eq!(1000001u128.decimal(&mut buffer), 7);
+    assert_eq!(&buffer[..7], b"1000001");
 
-        assert_eq!(9999999u128.decimal(&mut buffer), 7);
-        assert_eq!(&buffer[..7], b"9999999");
+    assert_eq!(9999999u128.decimal(&mut buffer), 7);
+    assert_eq!(&buffer[..7], b"9999999");
 
-        assert_eq!(10000001u128.decimal(&mut buffer), 8);
-        assert_eq!(&buffer[..8], b"10000001");
+    assert_eq!(10000001u128.decimal(&mut buffer), 8);
+    assert_eq!(&buffer[..8], b"10000001");
 
-        assert_eq!(99999999u128.decimal(&mut buffer), 8);
-        assert_eq!(&buffer[..8], b"99999999");
+    assert_eq!(99999999u128.decimal(&mut buffer), 8);
+    assert_eq!(&buffer[..8], b"99999999");
 
-        assert_eq!(100000001u128.decimal(&mut buffer), 9);
-        assert_eq!(&buffer[..9], b"100000001");
+    assert_eq!(100000001u128.decimal(&mut buffer), 9);
+    assert_eq!(&buffer[..9], b"100000001");
 
-        assert_eq!(999999999u128.decimal(&mut buffer), 9);
-        assert_eq!(&buffer[..9], b"999999999");
+    assert_eq!(999999999u128.decimal(&mut buffer), 9);
+    assert_eq!(&buffer[..9], b"999999999");
 
-        assert_eq!(1000000001u128.decimal(&mut buffer), 10);
-        assert_eq!(&buffer[..10], b"1000000001");
+    assert_eq!(1000000001u128.decimal(&mut buffer), 10);
+    assert_eq!(&buffer[..10], b"1000000001");
 
-        assert_eq!(9999999999u128.decimal(&mut buffer), 10);
-        assert_eq!(&buffer[..10], b"9999999999");
+    assert_eq!(9999999999u128.decimal(&mut buffer), 10);
+    assert_eq!(&buffer[..10], b"9999999999");
 
-        assert_eq!(10000000001u128.decimal(&mut buffer), 11);
-        assert_eq!(&buffer[..11], b"10000000001");
+    assert_eq!(10000000001u128.decimal(&mut buffer), 11);
+    assert_eq!(&buffer[..11], b"10000000001");
 
-        assert_eq!(99999999999u128.decimal(&mut buffer), 11);
-        assert_eq!(&buffer[..11], b"99999999999");
+    assert_eq!(99999999999u128.decimal(&mut buffer), 11);
+    assert_eq!(&buffer[..11], b"99999999999");
 
-        assert_eq!(100000000001u128.decimal(&mut buffer), 12);
-        assert_eq!(&buffer[..12], b"100000000001");
+    assert_eq!(100000000001u128.decimal(&mut buffer), 12);
+    assert_eq!(&buffer[..12], b"100000000001");
 
-        assert_eq!(999999999999u128.decimal(&mut buffer), 12);
-        assert_eq!(&buffer[..12], b"999999999999");
+    assert_eq!(999999999999u128.decimal(&mut buffer), 12);
+    assert_eq!(&buffer[..12], b"999999999999");
 
-        assert_eq!(1000000000001u128.decimal(&mut buffer), 13);
-        assert_eq!(&buffer[..13], b"1000000000001");
+    assert_eq!(1000000000001u128.decimal(&mut buffer), 13);
+    assert_eq!(&buffer[..13], b"1000000000001");
 
-        assert_eq!(9999999999999u128.decimal(&mut buffer), 13);
-        assert_eq!(&buffer[..13], b"9999999999999");
+    assert_eq!(9999999999999u128.decimal(&mut buffer), 13);
+    assert_eq!(&buffer[..13], b"9999999999999");
 
-        assert_eq!(10000000000001u128.decimal(&mut buffer), 14);
-        assert_eq!(&buffer[..14], b"10000000000001");
+    assert_eq!(10000000000001u128.decimal(&mut buffer), 14);
+    assert_eq!(&buffer[..14], b"10000000000001");
 
-        assert_eq!(99999999999999u128.decimal(&mut buffer), 14);
-        assert_eq!(&buffer[..14], b"99999999999999");
+    assert_eq!(99999999999999u128.decimal(&mut buffer), 14);
+    assert_eq!(&buffer[..14], b"99999999999999");
 
-        assert_eq!(100000000000001u128.decimal(&mut buffer), 15);
-        assert_eq!(&buffer[..15], b"100000000000001");
+    assert_eq!(100000000000001u128.decimal(&mut buffer), 15);
+    assert_eq!(&buffer[..15], b"100000000000001");
 
-        assert_eq!(999999999999999u128.decimal(&mut buffer), 15);
-        assert_eq!(&buffer[..15], b"999999999999999");
+    assert_eq!(999999999999999u128.decimal(&mut buffer), 15);
+    assert_eq!(&buffer[..15], b"999999999999999");
 
-        assert_eq!(1000000000000001u128.decimal(&mut buffer), 16);
-        assert_eq!(&buffer[..16], b"1000000000000001");
+    assert_eq!(1000000000000001u128.decimal(&mut buffer), 16);
+    assert_eq!(&buffer[..16], b"1000000000000001");
 
-        assert_eq!(9999999999999999u128.decimal(&mut buffer), 16);
-        assert_eq!(&buffer[..16], b"9999999999999999");
+    assert_eq!(9999999999999999u128.decimal(&mut buffer), 16);
+    assert_eq!(&buffer[..16], b"9999999999999999");
 
-        assert_eq!(10000000000000001u128.decimal(&mut buffer), 17);
-        assert_eq!(&buffer[..17], b"10000000000000001");
+    assert_eq!(10000000000000001u128.decimal(&mut buffer), 17);
+    assert_eq!(&buffer[..17], b"10000000000000001");
 
-        assert_eq!(99999999999999999u128.decimal(&mut buffer), 17);
-        assert_eq!(&buffer[..17], b"99999999999999999");
+    assert_eq!(99999999999999999u128.decimal(&mut buffer), 17);
+    assert_eq!(&buffer[..17], b"99999999999999999");
 
-        assert_eq!(100000000000000001u128.decimal(&mut buffer), 18);
-        assert_eq!(&buffer[..18], b"100000000000000001");
+    assert_eq!(100000000000000001u128.decimal(&mut buffer), 18);
+    assert_eq!(&buffer[..18], b"100000000000000001");
 
-        assert_eq!(999999999999999999u128.decimal(&mut buffer), 18);
-        assert_eq!(&buffer[..18], b"999999999999999999");
+    assert_eq!(999999999999999999u128.decimal(&mut buffer), 18);
+    assert_eq!(&buffer[..18], b"999999999999999999");
 
-        assert_eq!(1000000000000000001u128.decimal(&mut buffer), 19);
-        assert_eq!(&buffer[..19], b"1000000000000000001");
+    assert_eq!(1000000000000000001u128.decimal(&mut buffer), 19);
+    assert_eq!(&buffer[..19], b"1000000000000000001");
 
-        assert_eq!(9999999999999999999u128.decimal(&mut buffer), 19);
-        assert_eq!(&buffer[..19], b"9999999999999999999");
+    assert_eq!(9999999999999999999u128.decimal(&mut buffer), 19);
+    assert_eq!(&buffer[..19], b"9999999999999999999");
 
-        assert_eq!(10000000000000000001u128.decimal(&mut buffer), 20);
-        assert_eq!(&buffer[..20], b"10000000000000000001");
+    assert_eq!(10000000000000000001u128.decimal(&mut buffer), 20);
+    assert_eq!(&buffer[..20], b"10000000000000000001");
 
-        assert_eq!(999999999999999999999999u128.decimal(&mut buffer), 24);
-        assert_eq!(&buffer[..24], b"999999999999999999999999");
+    assert_eq!(999999999999999999999999u128.decimal(&mut buffer), 24);
+    assert_eq!(&buffer[..24], b"999999999999999999999999");
 
-        assert_eq!(1000000000000000000000001u128.decimal(&mut buffer), 25);
-        assert_eq!(&buffer[..25], b"1000000000000000000000001");
+    assert_eq!(1000000000000000000000001u128.decimal(&mut buffer), 25);
+    assert_eq!(&buffer[..25], b"1000000000000000000000001");
 
-        assert_eq!(66620387370000000000000000000u128.decimal(&mut buffer), 29);
-        assert_eq!(&buffer[..29], b"66620387370000000000000000000");
+    assert_eq!(66620387370000000000000000000u128.decimal(&mut buffer), 29);
+    assert_eq!(&buffer[..29], b"66620387370000000000000000000");
 
-        assert_eq!(99999999999999999999999999999u128.decimal(&mut buffer), 29);
-        assert_eq!(&buffer[..29], b"99999999999999999999999999999");
+    assert_eq!(99999999999999999999999999999u128.decimal(&mut buffer), 29);
+    assert_eq!(&buffer[..29], b"99999999999999999999999999999");
 
-        assert_eq!(100000000000000000000000000001u128.decimal(&mut buffer), 30);
-        assert_eq!(&buffer[..30], b"100000000000000000000000000001");
+    assert_eq!(100000000000000000000000000001u128.decimal(&mut buffer), 30);
+    assert_eq!(&buffer[..30], b"100000000000000000000000000001");
 
-        assert_eq!(9999999999999999999999999999999999u128.decimal(&mut buffer), 34);
-        assert_eq!(&buffer[..34], b"9999999999999999999999999999999999");
+    assert_eq!(9999999999999999999999999999999999u128.decimal(&mut buffer), 34);
+    assert_eq!(&buffer[..34], b"9999999999999999999999999999999999");
 
-        assert_eq!(10000000000000000000000000000000001u128.decimal(&mut buffer), 35);
-        assert_eq!(&buffer[..35], b"10000000000000000000000000000000001");
+    assert_eq!(10000000000000000000000000000000001u128.decimal(&mut buffer), 35);
+    assert_eq!(&buffer[..35], b"10000000000000000000000000000000001");
 
-        assert_eq!(340282366920938463463374607431768211455u128.decimal(&mut buffer), 39);
-        assert_eq!(&buffer[..39], b"340282366920938463463374607431768211455");
-    }
+    assert_eq!(340282366920938463463374607431768211455u128.decimal(&mut buffer), 39);
+    assert_eq!(&buffer[..39], b"340282366920938463463374607431768211455");
 }
 
 fn slow_log2(x: u32) -> usize {
@@ -443,7 +437,7 @@ quickcheck! {
     fn u32toa_quickcheck(x: u32) -> bool {
         let actual = x.to_string();
         let mut buffer = [b'\x00'; 16];
-        actual.len() == unsafe { x.decimal(&mut buffer) } &&
+        actual.len() == x.decimal(&mut buffer) &&
             &buffer[..actual.len()] == actual.as_bytes()
     }
 
@@ -451,7 +445,7 @@ quickcheck! {
     fn u64toa_quickcheck(x: u64) -> bool {
         let actual = x.to_string();
         let mut buffer = [b'\x00'; 32];
-        actual.len() == unsafe { x.decimal(&mut buffer) } &&
+        actual.len() == x.decimal(&mut buffer) &&
             &buffer[..actual.len()] == actual.as_bytes()
     }
 
@@ -459,7 +453,7 @@ quickcheck! {
     fn u128toa_quickcheck(x: u128) -> bool {
         let actual = x.to_string();
         let mut buffer = [b'\x00'; 48];
-        actual.len() == unsafe { x.decimal(&mut buffer) } &&
+        actual.len() == x.decimal(&mut buffer) &&
             &buffer[..actual.len()] == actual.as_bytes()
     }
 }

--- a/lexical-write-integer/tests/radix_tests.rs
+++ b/lexical-write-integer/tests/radix_tests.rs
@@ -14,9 +14,9 @@ use util::from_radix;
 fn u128toa_test() {
     const FORMAT: u128 = from_radix(12);
     let mut buffer = [b'\x00'; BUFFER_SIZE];
+    let value = 136551478823710021067381144334863695872u128;
+    let count = value.write_mantissa::<u128, FORMAT>(&mut buffer);
     unsafe {
-        let value = 136551478823710021067381144334863695872u128;
-        let count = value.write_mantissa::<u128, FORMAT>(&mut buffer);
         let y = u128::from_str_radix(from_utf8_unchecked(&buffer[..count]), 12);
         assert_eq!(y, Ok(value));
     }
@@ -25,11 +25,9 @@ fn u128toa_test() {
 #[cfg(feature = "power-of-two")]
 fn write_integer<T: WriteInteger, const FORMAT: u128>(x: T, actual: &[u8]) {
     let mut buffer = [b'\x00'; BUFFER_SIZE];
-    unsafe {
-        let count = x.write_mantissa::<T, FORMAT>(&mut buffer);
-        assert_eq!(actual.len(), count);
-        assert_eq!(actual, &buffer[..count])
-    }
+    let count = x.write_mantissa::<T, FORMAT>(&mut buffer);
+    assert_eq!(actual.len(), count);
+    assert_eq!(actual, &buffer[..count])
 }
 
 #[test]


### PR DESCRIPTION
This gets rid of almost all difficult to prove safety variants in the util and write-integer crates and with careful redesign, almost all of the unsafe use in both has been removed. Only `algorithm` still has some but due to the isolated nature of it and the easy-to-prove conditions of safety as long as the direct caller ensures the buffer size is sufficient, there is little risk of a large security vulnerability.

Documentation on the safety considerations has also been made prominent. This also makes it easier for security audits to find potential causes of vulnerabilities. The documentation will improve further.

This also fixes UB in our radix serializer.

![2024-09-13 02_00_45-Settings](https://github.com/user-attachments/assets/c418c2ca-6204-47cc-9dec-0ff130ae3e64)

Closes #126
Addressed #100 