### PR TITLE
Add in comprehensive formatting changes and optimizations.

### DIFF
--- a/.github/workflows/Comprehensive.yml
+++ b/.github/workflows/Comprehensive.yml
@@ -17,4 +17,3 @@ jobs:
             toolchain: nightly
             components: rustfmt, clippy
       - run: ci/comprehensive.sh
-      - run: ALL_FEATURES=1 ci/comprehensive.sh

--- a/ci/comprehensive.sh
+++ b/ci/comprehensive.sh
@@ -13,22 +13,24 @@ script_home=$(realpath "${script_dir}")
 home=$(dirname "${script_home}")
 cd "${home}"
 
-FEATURES=
-if [ ! -z $ALL_FEATURES ]; then
-    FEATURES=--all-features
-fi
+run_tests() {
+    # Test the parse-float correctness tests
+    cd "${home}"
+    cd lexical-parse-float/etc/correctness
+    cargo run "${@}" --release --bin test-parse-golang
+    cargo run "${@}" --release --bin test-parse-unittests
 
-# Test the parse-float correctness tests
-cd lexical-parse-float/etc/correctness
-cargo run $FEATURES --release --bin test-parse-golang
-cargo run $FEATURES --release --bin test-parse-unittests
+    # Test the write-float correctness tests.
+    cd "${home}"
+    cd lexical-write-float/etc/correctness
+    cargo run "${@}" --release --bin shorter_interval
+    cargo run "${@}" --release --bin random
+    cargo run "${@}" --release --bin simple_random  -- --iterations 1000000
+}
 
-# Test the write-float correctness tests.
-cd "${home}"
-cd lexical-write-float/etc/correctness
-cargo run $FEATURES --release --bin shorter_interval
-cargo run $FEATURES --release --bin random
-cargo run $FEATURES --release --bin simple_random  -- --iterations 1000000
+run_tests
+run_tests --features=format
+run_tests --all-features
 
 cd "${home}"
 if [ ! -z "${EXHAUSTIVE}" ]; then

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -109,3 +109,7 @@ cargo +nightly clippy --all-features -- --deny warnings
 ## Algorithm Changes
 
 Each workspace has a "docs" directory containing detailed descriptions of algorithms and benchmarks. If you make any substantial changes to an algorithm, you should both update the algorithm description and the provided benchmarks.
+
+## Pitfalls
+
+**ALWAYS** benchmark, even for trivial changes. I've been burned many times by `#[cfg(...)]` being way faster than `if cfg!()`, which youl would think both would be eliminated during optimization, just one during the first stage of compilation. It's better to confirm than assume. This is a nightmare development-wise because of how many features we support but there's not many alternatives: it seems it doesn't entirely remove code as if by tree-shaking which can majorly impact performance.

--- a/lexical-asm/src/lib.rs
+++ b/lexical-asm/src/lib.rs
@@ -1,10 +1,11 @@
 use core::num::ParseFloatError;
+use std::io::Write;
+
 use lexical_parse_float::FromLexical as FloatFromLexical;
 use lexical_parse_integer::FromLexical as IntFromLexical;
 use lexical_util::error::Error;
 use lexical_write_float::ToLexical as FloatToLexical;
 use lexical_write_integer::ToLexical as IntToLexical;
-use std::io::Write;
 
 // PARSE INTEGER
 // -------------

--- a/lexical-benchmark/algorithm/bigint.rs
+++ b/lexical-benchmark/algorithm/bigint.rs
@@ -1,4 +1,5 @@
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use fastrand::Rng;
 use lexical_parse_float::bigint;

--- a/lexical-benchmark/algorithm/division.rs
+++ b/lexical-benchmark/algorithm/division.rs
@@ -1,6 +1,7 @@
 mod input;
 
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 // Default random data size.

--- a/lexical-benchmark/input.rs
+++ b/lexical-benchmark/input.rs
@@ -6,6 +6,7 @@
 
 use core::fmt::Debug;
 use core::str::FromStr;
+
 use fastrand::Rng;
 #[cfg(feature = "floats")]
 use lexical_util::num::Float;
@@ -466,8 +467,9 @@ macro_rules! itoa_generator {
 
 macro_rules! fmt_generator {
     ($group:ident, $name:expr, $iter:expr) => {{
-        use lexical_util::constants::BUFFER_SIZE;
         use std::io::Write;
+
+        use lexical_util::constants::BUFFER_SIZE;
         let mut buffer = vec![b'0'; BUFFER_SIZE];
         $group.bench_function($name, |bench| {
             bench.iter(|| {

--- a/lexical-benchmark/parse-float/canada.rs
+++ b/lexical-benchmark/parse-float/canada.rs
@@ -2,6 +2,7 @@
 mod input;
 
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lexical_parse_float::FromLexical;
 

--- a/lexical-benchmark/parse-float/contrived.rs
+++ b/lexical-benchmark/parse-float/contrived.rs
@@ -3,9 +3,10 @@
 #[macro_use]
 mod input;
 
+use std::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lexical_parse_float::FromLexical;
-use std::time::Duration;
 
 // FLOATS
 

--- a/lexical-benchmark/parse-float/earth.rs
+++ b/lexical-benchmark/parse-float/earth.rs
@@ -2,6 +2,7 @@
 mod input;
 
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lexical_parse_float::FromLexical;
 

--- a/lexical-benchmark/parse-integer/json.rs
+++ b/lexical-benchmark/parse-integer/json.rs
@@ -2,6 +2,7 @@
 mod input;
 
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lexical_parse_integer::FromLexical;
 use serde::Deserialize;

--- a/lexical-benchmark/parse-integer/random.rs
+++ b/lexical-benchmark/parse-integer/random.rs
@@ -2,6 +2,7 @@
 mod input;
 
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lexical_parse_integer::FromLexical;
 

--- a/lexical-benchmark/write-float/json.rs
+++ b/lexical-benchmark/write-float/json.rs
@@ -2,6 +2,7 @@
 mod input;
 
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lexical_write_float::ToLexical;
 use serde::Deserialize;

--- a/lexical-benchmark/write-float/random.rs
+++ b/lexical-benchmark/write-float/random.rs
@@ -2,6 +2,7 @@
 mod input;
 
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lexical_write_float::ToLexical;
 

--- a/lexical-benchmark/write-integer/json.rs
+++ b/lexical-benchmark/write-integer/json.rs
@@ -2,6 +2,7 @@
 mod input;
 
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lexical_write_integer::ToLexical;
 use serde::Deserialize;

--- a/lexical-benchmark/write-integer/random.rs
+++ b/lexical-benchmark/write-integer/random.rs
@@ -2,6 +2,7 @@
 mod input;
 
 use core::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lexical_write_integer::ToLexical;
 

--- a/lexical-core/src/lib.rs
+++ b/lexical-core/src/lib.rs
@@ -77,7 +77,6 @@
 //! ```
 //!
 //! # Conversion API
-//!
 #![cfg_attr(feature = "write", doc = " **Write**")]
 #![cfg_attr(feature = "write", doc = "")]
 #![cfg_attr(feature = "write", doc = " - [`write`]")]
@@ -93,8 +92,8 @@
 //! # Features
 //!
 //! In accordance with the Rust ethos, all features are additive: the crate
-//! may be build with `--all-features` without issue.  The following features are enabled
-//! by default:
+//! may be build with `--all-features` without issue.  The following features
+//! are enabled by default:
 //!
 //! * `std`
 //! * `write-integers`
@@ -197,7 +196,7 @@
 //!
 //! Lexical provides two main levels of configuration:
 //! - The [`NumberFormatBuilder`], creating a packed struct with custom
-//!     formatting options.
+//!   formatting options.
 //! - The Options API.
 //!
 //! ## Number Format
@@ -212,8 +211,10 @@
 //! When the `format` feature is enabled, numerous other syntax and
 //! digit separator flags are enabled, including:
 //! - A digit separator character, to group digits for increased legibility.
-//! - Whether leading, trailing, internal, and consecutive digit separators are allowed.
-//! - Toggling required float components, such as digits before the decimal point.
+//! - Whether leading, trailing, internal, and consecutive digit separators are
+//!   allowed.
+//! - Toggling required float components, such as digits before the decimal
+//!   point.
 //! - Toggling whether special floats are allowed or are case-sensitive.
 //!
 //! Many pre-defined constants therefore exist to simplify common use-cases,
@@ -235,7 +236,6 @@
 //! - The rounding mode when truncating significant digits while writing.
 //!
 //! The available options are:
-//!
 #![cfg_attr(feature = "parse-floats", doc = " - [`ParseFloatOptions`]")]
 #![cfg_attr(feature = "parse-integers", doc = " - [`ParseIntegerOptions`]")]
 #![cfg_attr(feature = "write-floats", doc = " - [`WriteFloatOptions`]")]
@@ -298,7 +298,8 @@
 //! - [Writing Integers](https://github.com/Alexhuszagh/rust-lexical/blob/main/lexical-write-integer/docs/Benchmarks.md)
 //! - [Comprehensive Benchmarks](https://github.com/Alexhuszagh/lexical-benchmarks)
 //!
-//! A comprehensive analysis of lexical commits and their performance can be found in [benchmarks].
+//! A comprehensive analysis of lexical commits and their performance can be
+//! found in [benchmarks].
 //!
 //! # Design
 //!
@@ -339,25 +340,6 @@
 #![cfg_attr(feature = "lint", warn(unsafe_op_in_unsafe_fn))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "parse-floats")]
-use lexical_parse_float::{
-    FromLexical as FromFloat,
-    FromLexicalWithOptions as FromFloatWithOptions,
-};
-#[cfg(feature = "parse-integers")]
-use lexical_parse_integer::{
-    FromLexical as FromInteger,
-    FromLexicalWithOptions as FromIntegerWithOptions,
-};
-#[cfg(feature = "parse")]
-use lexical_util::{from_lexical, from_lexical_with_options};
-#[cfg(feature = "write")]
-use lexical_util::{to_lexical, to_lexical_with_options};
-#[cfg(feature = "write-floats")]
-use lexical_write_float::{ToLexical as ToFloat, ToLexicalWithOptions as ToFloatWithOptions};
-#[cfg(feature = "write-integers")]
-use lexical_write_integer::{ToLexical as ToInteger, ToLexicalWithOptions as ToIntegerWithOptions};
-
 // Re-exports
 #[cfg(feature = "parse-floats")]
 pub use lexical_parse_float::{
@@ -365,11 +347,21 @@ pub use lexical_parse_float::{
     Options as ParseFloatOptions,
     OptionsBuilder as ParseFloatOptionsBuilder,
 };
+#[cfg(feature = "parse-floats")]
+use lexical_parse_float::{
+    FromLexical as FromFloat,
+    FromLexicalWithOptions as FromFloatWithOptions,
+};
 #[cfg(feature = "parse-integers")]
 pub use lexical_parse_integer::{
     options as parse_integer_options,
     Options as ParseIntegerOptions,
     OptionsBuilder as ParseIntegerOptionsBuilder,
+};
+#[cfg(feature = "parse-integers")]
+use lexical_parse_integer::{
+    FromLexical as FromInteger,
+    FromLexicalWithOptions as FromIntegerWithOptions,
 };
 #[cfg(feature = "f16")]
 pub use lexical_util::bf16::bf16;
@@ -386,18 +378,26 @@ pub use lexical_util::options::ParseOptions;
 pub use lexical_util::options::WriteOptions;
 #[cfg(feature = "parse")]
 pub use lexical_util::result::Result;
+#[cfg(feature = "parse")]
+use lexical_util::{from_lexical, from_lexical_with_options};
+#[cfg(feature = "write")]
+use lexical_util::{to_lexical, to_lexical_with_options};
 #[cfg(feature = "write-floats")]
 pub use lexical_write_float::{
     options as write_float_options,
     Options as WriteFloatOptions,
     OptionsBuilder as WriteFloatOptionsBuilder,
 };
+#[cfg(feature = "write-floats")]
+use lexical_write_float::{ToLexical as ToFloat, ToLexicalWithOptions as ToFloatWithOptions};
 #[cfg(feature = "write-integers")]
 pub use lexical_write_integer::{
     options as write_integer_options,
     Options as WriteIntegerOptions,
     OptionsBuilder as WriteIntegerOptionsBuilder,
 };
+#[cfg(feature = "write-integers")]
+use lexical_write_integer::{ToLexical as ToInteger, ToLexicalWithOptions as ToIntegerWithOptions};
 
 // API
 // ---
@@ -414,8 +414,10 @@ to_lexical_with_options!();
 /// Implement `FromLexical` and `FromLexicalWithOptions` for numeric types.
 ///
 /// * `t`                           - The numerical type.
-/// * `from`                        - The internal trait that implements `from_lexical`.
-/// * `from_lexical_with_options`   - The internal trait that implements `from_lexical`.
+/// * `from`                        - The internal trait that implements
+///   `from_lexical`.
+/// * `from_lexical_with_options`   - The internal trait that implements
+///   `from_lexical`.
 /// * `options`                     - The options type to configure settings.
 #[cfg(feature = "parse")]
 macro_rules! from_lexical_impl {
@@ -479,8 +481,10 @@ float_from_lexical! { f32 f64 }
 /// Implement `ToLexical` and `ToLexicalWithOptions` for numeric types.
 ///
 /// * `t`                           - The numerical type.
-/// * `to`                          - The internal trait that implements `to_lexical`.
-/// * `to_lexical_with_options`     - The internal trait that implements `to_lexical`.
+/// * `to`                          - The internal trait that implements
+///   `to_lexical`.
+/// * `to_lexical_with_options`     - The internal trait that implements
+///   `to_lexical`.
 /// * `options`                     - The options type to configure settings.
 #[cfg(feature = "write")]
 macro_rules! to_lexical_impl {

--- a/lexical-parse-float/etc/bellerophon_table.py
+++ b/lexical-parse-float/etc/bellerophon_table.py
@@ -1,18 +1,20 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+'''
+    bellerophon_table
+    =================
 
-"""
-Generate powers of a given radix for the Bellerophon algorithm.
+    Generate powers of a given radix for the Bellerophon algorithm.
 
-Specifically, computes and outputs (as Rust code) a table of 10^e for some
-range of exponents e. The output is one array of 128 bit significands.
-The base two exponents can be inferred using a logarithmic slope
-of the decimal exponent. The approximations are normalized and rounded perfectly,
-i.e., within 0.5 ULP of the true value.
+    Specifically, computes and outputs (as Rust code) a table of 10^e for some
+    range of exponents e. The output is one array of 128 bit significands.
+    The base two exponents can be inferred using a logarithmic slope
+    of the decimal exponent. The approximations are normalized and rounded perfectly,
+    i.e., within 0.5 ULP of the true value.
 
-Ported from Rust's core library implementation, which itself is
-adapted from Daniel Lemire's fast_float ``table_generation.py``,
-available here: <https://github.com/fastfloat/fast_float/blob/main/script/table_generation.py>.
-"""
+    Ported from Rust's core library implementation, which itself is
+    adapted from Daniel Lemire's fast_float ``table_generation.py``,
+    available here: <https://github.com/fastfloat/fast_float/blob/main/script/table_generation.py>.
+'''
 
 import math
 from collections import deque
@@ -33,7 +35,10 @@ POWER_STR = """pub static BASE{0}_POWERS: BellerophonPowers = BellerophonPowers 
     bias: BASE{0}_BIAS,
 }};\n"""
 
-def calculate_bitshift(base, exponent):
+Fp = tuple[int, int]
+
+
+def calculate_bitshift(base: int, exponent: int) -> float:
     '''
     Calculate the bitshift required for a given base. The exponent
     is the absolute value of the max exponent (log distance from 1.)
@@ -42,19 +47,19 @@ def calculate_bitshift(base, exponent):
     return 63 + math.ceil(math.log2(base**exponent))
 
 
-def next_fp(fp, base, step = 1):
+def next_fp(fp: Fp, base: int, step: int = 1) -> Fp:
     '''Generate the next extended-floating point value.'''
 
     return (fp[0] * (base**step), fp[1])
 
 
-def prev_fp(fp, base, step = 1):
+def prev_fp(fp: Fp, base: int, step: int = 1) -> Fp:
     '''Generate the previous extended-floating point value.'''
 
     return (fp[0] // (base**step), fp[1])
 
 
-def normalize_fp(fp):
+def normalize_fp(fp: Fp) -> Fp:
     '''Normalize a extended-float so the MSB is the 64th bit'''
 
     while fp[0] >> 64 != 0:
@@ -62,7 +67,7 @@ def normalize_fp(fp):
     return fp
 
 
-def generate_small(base, count):
+def generate_small(base: int, count: int) -> tuple[list[Fp], list[int]]:
     '''Generate the small powers for a given base'''
 
     bitshift = calculate_bitshift(base, count)
@@ -78,7 +83,7 @@ def generate_small(base, count):
     return fps, ints
 
 
-def generate_large(base, step):
+def generate_large(base: int, step: int) -> tuple[list[Fp], int]:
     '''Generate the large powers for a given base.'''
 
     # Get our starting parameters
@@ -106,7 +111,7 @@ def generate_large(base, step):
     return fps, -fps[0][1]
 
 
-def print_array(base, string, fps, index):
+def print_array(base: int, string: str, fps: list[Fp], index: int) -> None:
     '''Print an entire array'''
 
     print(string.format(base, len(fps)))
@@ -117,7 +122,7 @@ def print_array(base, string, fps, index):
     print("];")
 
 
-def generate_base(base):
+def generate_base(base: int) -> None:
     '''Generate all powers and variables.'''
 
     step = math.floor(math.log(1e10, base))
@@ -133,7 +138,7 @@ def generate_base(base):
     print(BIAS_STR.format(base, bias))
 
 
-def generate():
+def generate() -> None:
     '''Generate all bases.'''
 
     bases = [

--- a/lexical-parse-float/etc/lemire_table.py
+++ b/lexical-parse-float/etc/lemire_table.py
@@ -1,22 +1,23 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+'''
+    lemire_table
+    ============
 
-"""
-Generate powers of five using Daniel Lemire's ``Eisel-Lemire algorithm`` for use in
-decimal to floating point conversions.
+    Generate powers of five using Daniel Lemire's ``Eisel-Lemire algorithm`` for use in
+    decimal to floating point conversions.
 
-Specifically, computes and outputs (as Rust code) a table of 10^e for some
-range of exponents e. The output is one array of 128 bit significands.
-The base two exponents can be inferred using a logarithmic slope
-of the decimal exponent. The approximations are normalized and rounded perfectly,
-i.e., within 0.5 ULP of the true value.
+    Specifically, computes and outputs (as Rust code) a table of 10^e for some
+    range of exponents e. The output is one array of 128 bit significands.
+    The base two exponents can be inferred using a logarithmic slope
+    of the decimal exponent. The approximations are normalized and rounded perfectly,
+    i.e., within 0.5 ULP of the true value.
 
-Ported from Rust's core library implementation, which itself is
-adapted from Daniel Lemire's fast_float ``table_generation.py``,
-available here: <https://github.com/fastfloat/fast_float/blob/main/script/table_generation.py>.
-"""
-from __future__ import print_function
-from math import ceil, floor, log, log2
-from fractions import Fraction
+    Ported from Rust's core library implementation, which itself is
+    adapted from Daniel Lemire's fast_float ``table_generation.py``,
+    available here: <https://github.com/fastfloat/fast_float/blob/main/script/table_generation.py>.
+'''
+
+from math import ceil, floor, log
 from collections import deque
 
 HEADER = """
@@ -35,6 +36,7 @@ STATIC_WARNING = """
 // emit code multiple times, even if it's stripped out in
 // the final binary.
 """
+
 
 def main():
     min_exp = minimum_exponent(10)
@@ -78,7 +80,7 @@ def print_proper_powers(min_exp, max_exp, bias):
             b = 2 * z + 2 * 64
             c = 2 ** b // power5 + 1
             # truncate
-            while c >= (1<<128):
+            while c >= (1 << 128):
                 c //= 2
             powers.append((c, q))
 
@@ -86,10 +88,10 @@ def print_proper_powers(min_exp, max_exp, bias):
     for q in range(0, max_exp + 1):
         power5 = 5 ** q
         # move the most significant bit in position
-        while power5 < (1<<127):
+        while power5 < (1 << 127):
             power5 *= 2
         # *truncate*
-        while power5 >= (1<<128):
+        while power5 >= (1 << 128):
             power5 //= 2
         powers.append((power5, q))
 
@@ -98,7 +100,6 @@ def print_proper_powers(min_exp, max_exp, bias):
     print('#[rustfmt::skip]')
     typ = '[(u64, u64); N_POWERS_OF_FIVE]'
     print('pub static POWER_OF_FIVE_128: {} = ['.format(typ))
-    lo_mask = (1 << 64) - 1
     for c, exp in powers:
         hi = '0x{:x}'.format(c // (1 << 64))
         lo = '0x{:x}'.format(c % (1 << 64))

--- a/lexical-parse-float/etc/limits.py
+++ b/lexical-parse-float/etc/limits.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
+'''
+    limits
+    ======
 
-"""
-Generate the numeric limits for a given radix.
+    Generate the numeric limits for a given radix.
 
-This is used for the fast-path algorithms, to calculate the
-maximum number of digits or exponent bits that can be exactly
-represented as a native value.
-"""
+    This is used for the fast-path algorithms, to calculate the
+    maximum number of digits or exponent bits that can be exactly
+    represented as a native value.
+
+    Note that we need to use `#[cfg]` rather than `if cfg!(...)`
+    due to performance reasons. The code is broken down in
+    the actual implementation to move the powers to const fns
+    and then implement the trait in terms of the const fns.
+'''
 
 import math
 

--- a/lexical-parse-float/etc/powers_table.py
+++ b/lexical-parse-float/etc/powers_table.py
@@ -1,12 +1,15 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+'''
+    powers_table
+    ============
 
-"""
-Generate powers of a given radix.
+    Generate powers of a given radix.
 
-This is used for both the fast-path algorithms, for native
-multiplication, and as pre-computed powers for exponentiation
-for the slow path algorithms.
-"""
+    This is used for both the fast-path algorithms, for native
+    multiplication, and as pre-computed powers for exponentiation
+    for the slow path algorithms.
+'''
+
 
 def print_int(radix, max_exp):
     '''Print pre-computed small powers as u64.'''
@@ -20,6 +23,7 @@ def print_int(radix, max_exp):
     print(f'const_assert!(SMALL_INT_POW{radix}.len() == u64_power_limit({radix}) as usize + 1);')
     print('')
 
+
 def print_f32(radix, max_exp):
     '''Print pre-computed small powers as f32.'''
 
@@ -30,6 +34,7 @@ def print_f32(radix, max_exp):
     print('];')
     print(f'const_assert!(SMALL_F32_POW{radix}.len() > f32_exponent_limit({radix}).1 as usize);')
     print('')
+
 
 def print_f64(radix, max_exp):
     '''Print pre-computed small powers as f64.'''
@@ -42,6 +47,7 @@ def print_f64(radix, max_exp):
     print(f'const_assert!(SMALL_F64_POW{radix}.len() > f64_exponent_limit({radix}).1 as usize);')
     print('')
 
+
 def as_u32(value):
     '''Convert a big integer to an array of 32-bit values.'''
 
@@ -52,6 +58,7 @@ def as_u32(value):
         value >>= 32
     return result
 
+
 def as_u64(value):
     '''Convert a big integer to an array of 64-bit values.'''
 
@@ -61,6 +68,7 @@ def as_u64(value):
         result.append(value & max_u64)
         value >>= 64
     return result
+
 
 def print_large(radix, max_exp):
     '''Print a pre-computed large power as a native limb.'''
@@ -87,12 +95,14 @@ def print_large(radix, max_exp):
     print(f'pub const LARGE_POW{radix}_STEP: u32 = {5 * max_exp};')
     print(f'')
 
+
 def print_tables(radix, f64_pow_limit, f32_exp_limit, f64_exp_limit):
     print_int(radix, f64_pow_limit)
     print_f32(radix, f32_exp_limit)
     print_f64(radix, f64_exp_limit)
     if radix % 2 != 0:
         print_large(radix, f64_pow_limit)
+
 
 def f32_exponent_limit(radix):
     return {
@@ -127,6 +137,7 @@ def f32_exponent_limit(radix):
         36: (-7, 7),
     }[radix]
 
+
 def f64_exponent_limit(radix):
     return {
         3: (-33, 33),
@@ -160,6 +171,7 @@ def f64_exponent_limit(radix):
         36: (-16, 16),
     }[radix]
 
+
 def f64_power_limit(radix):
     return {
         3: 40,
@@ -192,6 +204,7 @@ def f64_power_limit(radix):
         35: 12,
         36: 12
     }[radix]
+
 
 radixes = [3, 5, 6, 7, 9, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 33, 34, 35, 36]
 for radix in radixes:

--- a/lexical-parse-float/src/api.rs
+++ b/lexical-parse-float/src/api.rs
@@ -2,8 +2,6 @@
 
 #![doc(hidden)]
 
-use crate::options::Options;
-use crate::parse::ParseFloat;
 #[cfg(feature = "f16")]
 use lexical_util::bf16::bf16;
 use lexical_util::error::Error;
@@ -11,6 +9,9 @@ use lexical_util::error::Error;
 use lexical_util::f16::f16;
 use lexical_util::format::{is_valid_options_punctuation, NumberFormat, STANDARD};
 use lexical_util::{from_lexical, from_lexical_with_options};
+
+use crate::options::Options;
+use crate::parse::ParseFloat;
 
 // API
 

--- a/lexical-parse-float/src/bellerophon.rs
+++ b/lexical-parse-float/src/bellerophon.rs
@@ -17,12 +17,13 @@
 #![cfg(any(feature = "compact", feature = "radix"))]
 #![doc(hidden)]
 
+use lexical_util::format::NumberFormat;
+
 use crate::float::{ExtendedFloat80, RawFloat};
 use crate::mask::{lower_n_halfway, lower_n_mask};
 use crate::number::Number;
 use crate::shared;
 use crate::table::bellerophon_powers;
-use lexical_util::format::NumberFormat;
 
 // ALGORITHM
 // ---------
@@ -315,7 +316,8 @@ pub fn normalize(fp: &mut ExtendedFloat80) -> i32 {
 /// set. The result is not normalized.
 ///
 /// Algorithm:
-///     1. Non-signed multiplication of mantissas (requires 2x as many bits as input).
+///     1. Non-signed multiplication of mantissas (requires 2x as many bits as
+///        input).
 ///     2. Normalization of the result (not done here).
 ///     3. Addition of exponents.
 #[cfg_attr(not(feature = "compact"), inline(always))]

--- a/lexical-parse-float/src/bigint.rs
+++ b/lexical-parse-float/src/bigint.rs
@@ -29,7 +29,7 @@ macro_rules! index_unchecked {
 macro_rules! index_unchecked {
     ($x:ident[$i:expr]) => {
         // SAFETY: safe if `index < array.len()`.
-        $x.get_unchecked($i)
+        *$x.get_unchecked($i)
     };
 }
 
@@ -289,15 +289,15 @@ pub struct StackVec<const SIZE: usize> {
 /// - `fn`      - The callback to extract the high bits.
 macro_rules! hi {
     (@1 $self:ident, $rview:ident, $t:ident, $fn:ident) => {{
-        $fn(unsafe { *index_unchecked!($rview[0]) as $t })
+        $fn(unsafe { index_unchecked!($rview[0]) as $t })
     }};
 
     // # Safety
     //
     // Safe as long as the `stackvec.len() >= 2`.
     (@2 $self:ident, $rview:ident, $t:ident, $fn:ident) => {{
-        let r0 = unsafe { *index_unchecked!($rview[0]) as $t };
-        let r1 = unsafe { *index_unchecked!($rview[1]) as $t };
+        let r0 = unsafe { index_unchecked!($rview[0]) as $t };
+        let r1 = unsafe { index_unchecked!($rview[1]) as $t };
         $fn(r0, r1)
     }};
 
@@ -313,9 +313,9 @@ macro_rules! hi {
     //
     // Safe as long as the `stackvec.len() >= 3`.
     (@3 $self:ident, $rview:ident, $t:ident, $fn:ident) => {{
-        let r0 = unsafe { *index_unchecked!($rview[0]) as $t };
-        let r1 = unsafe { *index_unchecked!($rview[1]) as $t };
-        let r2 = unsafe { *index_unchecked!($rview[2]) as $t };
+        let r0 = unsafe { index_unchecked!($rview[0]) as $t };
+        let r1 = unsafe { index_unchecked!($rview[1]) as $t };
+        let r2 = unsafe { index_unchecked!($rview[2]) as $t };
         $fn(r0, r1, r2)
     }};
 
@@ -1236,7 +1236,7 @@ pub fn large_mul<const SIZE: usize>(x: &mut StackVec<SIZE>, y: &[Limb]) -> Optio
     // multiplication.
     if y.len() == 1 {
         // SAFETY: safe since `y.len() == 1`.
-        small_mul(x, unsafe { *index_unchecked!(y[0]) })?;
+        small_mul(x, unsafe { index_unchecked!(y[0]) })?;
     } else {
         *x = long_mul(y, x)?;
     }

--- a/lexical-parse-float/src/binary.rs
+++ b/lexical-parse-float/src/binary.rs
@@ -6,16 +6,17 @@
 #![cfg(feature = "power-of-two")]
 #![doc(hidden)]
 
-use crate::float::{ExtendedFloat80, RawFloat};
-use crate::mask::lower_n_halfway;
-use crate::number::Number;
-use crate::shared;
 #[cfg(not(feature = "compact"))]
 use lexical_parse_integer::algorithm;
 use lexical_util::digit::char_to_valid_digit_const;
 use lexical_util::format::NumberFormat;
 use lexical_util::iterator::{AsBytes, BytesIter};
 use lexical_util::step::u64_step;
+
+use crate::float::{ExtendedFloat80, RawFloat};
+use crate::mask::lower_n_halfway;
+use crate::number::Number;
+use crate::shared;
 
 // ALGORITHM
 // ---------

--- a/lexical-parse-float/src/float.rs
+++ b/lexical-parse-float/src/float.rs
@@ -5,17 +5,18 @@
 
 #![doc(hidden)]
 
-#[cfg(all(not(feature = "std"), feature = "compact"))]
-use crate::libm::{powd, powf};
-use crate::limits::{ExactFloat, MaxDigits};
-#[cfg(not(feature = "compact"))]
-use crate::table::{get_small_f32_power, get_small_f64_power, get_small_int_power};
 #[cfg(feature = "f16")]
 use lexical_util::bf16::bf16;
 use lexical_util::extended_float::ExtendedFloat;
 #[cfg(feature = "f16")]
 use lexical_util::f16::f16;
 use lexical_util::num::{AsCast, Float};
+
+#[cfg(all(not(feature = "std"), feature = "compact"))]
+use crate::libm::{powd, powf};
+use crate::limits::{ExactFloat, MaxDigits};
+#[cfg(not(feature = "compact"))]
+use crate::table::{get_small_f32_power, get_small_f64_power, get_small_int_power};
 
 /// Alias with ~80 bits of precision, 64 for the mantissa and 16 for exponent.
 /// This exponent is biased, and if the exponent is negative, it represents
@@ -30,15 +31,17 @@ pub trait RawFloat: Float + ExactFloat + MaxDigits {
     // Largest exponent value `(1 << EXP_BITS) - 1`.
     const INFINITE_POWER: i32 = Self::MAX_EXPONENT + Self::EXPONENT_BIAS;
 
-    /// Minimum exponent that for a fast path case, or `-⌊(MANTISSA_SIZE+1)/log2(r)⌋`
-    /// where `r` is the radix with powers-of-two removed.
+    /// Minimum exponent that for a fast path case, or
+    /// `-⌊(MANTISSA_SIZE+1)/log2(r)⌋` where `r` is the radix with
+    /// powers-of-two removed.
     #[inline(always)]
     fn min_exponent_fast_path(radix: u32) -> i64 {
         Self::exponent_limit(radix).0
     }
 
-    /// Maximum exponent that for a fast path case, or `⌊(MANTISSA_SIZE+1)/log2(r)⌋`
-    /// where `r` is the radix with powers-of-two removed.
+    /// Maximum exponent that for a fast path case, or
+    /// `⌊(MANTISSA_SIZE+1)/log2(r)⌋` where `r` is the radix with
+    /// powers-of-two removed.
     #[inline(always)]
     fn max_exponent_fast_path(radix: u32) -> i64 {
         Self::exponent_limit(radix).1
@@ -106,7 +109,8 @@ impl RawFloat for bf16 {
     }
 }
 
-/// Helper trait to add more float characteristics for the Eisel-Lemire algorithm.
+/// Helper trait to add more float characteristics for the Eisel-Lemire
+/// algorithm.
 pub trait LemireFloat: RawFloat {
     // Round-to-even only happens for negative values of q
     // when q ≥ −4 in the 64-bit case and when q ≥ −17 in

--- a/lexical-parse-float/src/lemire.rs
+++ b/lexical-parse-float/src/lemire.rs
@@ -11,7 +11,8 @@ use crate::number::Number;
 use crate::shared;
 use crate::table::{LARGEST_POWER_OF_FIVE, POWER_OF_FIVE_128, SMALLEST_POWER_OF_FIVE};
 
-/// Ensure truncation of digits doesn't affect our computation, by doing 2 passes.
+/// Ensure truncation of digits doesn't affect our computation, by doing 2
+/// passes.
 #[inline(always)]
 pub fn lemire<F: LemireFloat>(num: &Number, lossy: bool) -> ExtendedFloat80 {
     // If significant digits were truncated, then we can have rounding error
@@ -113,8 +114,8 @@ pub fn compute_float<F: LemireFloat>(q: i64, mut w: u64, lossy: bool) -> Extende
     // need to round down.
     //
     // This will only occur if:
-    //  1. The lower 64 bits of the 128-bit representation is 0.
-    //      IE, 5^q fits in single 64-bit word.
+    //  1. The lower 64 bits of the 128-bit representation is 0. IE, 5^q fits in
+    //     single 64-bit word.
     //  2. The least-significant bit prior to truncated mantissa is odd.
     //  3. All the bits truncated when shifting to mantissa bits + 1 are 0.
     //
@@ -164,7 +165,8 @@ pub fn compute_error<F: LemireFloat>(q: i64, mut w: u64) -> ExtendedFloat80 {
 /// Compute the error from a mantissa scaled to the exponent.
 #[inline(always)]
 pub fn compute_error_scaled<F: LemireFloat>(q: i64, mut w: u64, lz: i32) -> ExtendedFloat80 {
-    // Want to normalize the float, but this is faster than ctlz on most architectures.
+    // Want to normalize the float, but this is faster than ctlz on most
+    // architectures.
     let hilz = (w >> 63) as i32 ^ 1;
     w <<= hilz;
     let power2 = power(q as i32) + F::EXPONENT_BIAS - hilz - lz - 62;
@@ -190,9 +192,10 @@ fn full_multiplication(a: u64, b: u64) -> (u64, u64) {
     (r as u64, (r >> 64) as u64)
 }
 
-// This will compute or rather approximate w * 5**q and return a pair of 64-bit words
-// approximating the result, with the "high" part corresponding to the most significant
-// bits and the low part corresponding to the least significant bits.
+// This will compute or rather approximate w * 5**q and return a pair of 64-bit
+// words approximating the result, with the "high" part corresponding to the
+// most significant bits and the low part corresponding to the least significant
+// bits.
 fn compute_product_approx(q: i64, w: u64, precision: usize) -> (u64, u64) {
     debug_assert!(q >= SMALLEST_POWER_OF_FIVE as i64);
     debug_assert!(q <= LARGEST_POWER_OF_FIVE as i64);

--- a/lexical-parse-float/src/lib.rs
+++ b/lexical-parse-float/src/lib.rs
@@ -72,15 +72,16 @@
 //!
 //! # Safety
 //!
-//! The primary use of unsafe code is in the big integer implementation, which for
-//! performance reasons requires unchecked indexing at certain points, where rust
-//! cannot elide the index check. The use of unsafe code can be found in the
-//! calculation of the [hi] bits, however, every invocation requires the buffer to
-//! be of sufficient [length][longbits]. The other major source is the implementation
-//! of methods such as [push_unchecked], however, the safety invariants for each caller
-//! to create a safe API are documented and has similar safety guarantees to a regular
-//! vector. All other invocations of unsafe code are indexing a buffer where the index
-//! is proven to be within bounds within a few lines of code of the unsafe index.
+//! The primary use of unsafe code is in the big integer implementation, which
+//! for performance reasons requires unchecked indexing at certain points, where
+//! rust cannot elide the index check. The use of unsafe code can be found in
+//! the calculation of the [hi] bits, however, every invocation requires the
+//! buffer to be of sufficient [length][longbits]. The other major source is the
+//! implementation of methods such as [push_unchecked], however, the safety
+//! invariants for each caller to create a safe API are documented and has
+//! similar safety guarantees to a regular vector. All other invocations of
+//! unsafe code are indexing a buffer where the index is proven to be within
+//! bounds within a few lines of code of the unsafe index.
 //!
 //! # Design
 //!
@@ -128,9 +129,6 @@ mod table_radix;
 mod table_small;
 
 // Re-exports
-pub use self::api::{FromLexical, FromLexicalWithOptions};
-#[doc(inline)]
-pub use self::options::{Options, OptionsBuilder};
 #[cfg(feature = "f16")]
 pub use lexical_util::bf16::bf16;
 pub use lexical_util::error::Error;
@@ -139,3 +137,7 @@ pub use lexical_util::f16::f16;
 pub use lexical_util::format::{self, NumberFormatBuilder};
 pub use lexical_util::options::ParseOptions;
 pub use lexical_util::result::Result;
+
+pub use self::api::{FromLexical, FromLexicalWithOptions};
+#[doc(inline)]
+pub use self::options::{Options, OptionsBuilder};

--- a/lexical-parse-float/src/libm.rs
+++ b/lexical-parse-float/src/libm.rs
@@ -6,6 +6,7 @@
 
 #![cfg(all(not(feature = "std"), feature = "compact"))]
 #![doc(hidden)]
+#![cfg_attr(any(), rustfmt::skip)]
 
 /* origin: FreeBSD /usr/src/lib/msun/src/e_powf.c */
 /*
@@ -29,16 +30,20 @@
 /// Safe if `index < array.len()`.
 #[cfg(feature = "safe")]
 macro_rules! i {
-    ($x:ident[$i:expr]) => {
+    ($x:ident, $i:expr) => {
         $x[$i]
     };
 }
 
+/// Index an array without bounds checking.
+///
+/// # Safety
+///
+/// Safe if `index < array.len()`.
 #[cfg(not(feature = "safe"))]
 macro_rules! i {
-    ($x:ident[$i:expr]) => {
-        // SAFETY: safe if `index < array.len()`.
-        $x.get_unchecked($i)
+    ($x:ident, $i:expr) => {
+        unsafe { *$x.get_unchecked($i) }
     };
 }
 

--- a/lexical-parse-float/src/libm.rs
+++ b/lexical-parse-float/src/libm.rs
@@ -27,16 +27,18 @@
 /// # Safety
 ///
 /// Safe if `index < array.len()`.
+#[cfg(feature = "safe")]
 macro_rules! i {
-    ($array:ident, $index:expr) => {
+    ($x:ident[$i:expr]) => {
+        $x[$i]
+    };
+}
+
+#[cfg(not(feature = "safe"))]
+macro_rules! i {
+    ($x:ident[$i:expr]) => {
         // SAFETY: safe if `index < array.len()`.
-        unsafe {
-            if cfg!(feature = "safe") {
-                $array[$index]
-            } else {
-                *$array.get_unchecked($index)
-            }
-        }
+        $x.get_unchecked($i)
     };
 }
 
@@ -264,7 +266,7 @@ pub fn powf(x: f32, y: f32) -> f32 {
             /* |x|<sqrt(3/2) */
             k = 0;
         } else if j < 0x5db3d7 {
-            /* |x|<sqrt(3)   */
+            /* |x|<sqrt(3) */
             k = 1;
         } else {
             k = 0;
@@ -430,7 +432,8 @@ pub fn sqrtf(x: f32) -> f32 {
 
         /* take care of Inf and NaN */
         if (ix as u32 & 0x7f800000) == 0x7f800000 {
-            return x * x + x; /* sqrt(NaN)=NaN, sqrt(+inf)=+inf, sqrt(-inf)=sNaN */
+            return x * x + x; /* sqrt(NaN)=NaN, sqrt(+inf)=+inf,
+                               * sqrt(-inf)=sNaN */
         }
 
         /* take care of zero */
@@ -549,33 +552,35 @@ pub fn scalbnf(mut x: f32, mut n: i32) -> f32 {
 //
 //                    n
 // Method:  Let x =  2   * (1+f)
-//      1. Compute and return log2(x) in two pieces:
-//              log2(x) = w1 + w2,
-//         where w1 has 53-24 = 29 bit trailing zeros.
-//      2. Perform y*log2(x) = n+y' by simulating muti-precision
-//         arithmetic, where |y'|<=0.5.
+//      1. Compute and return log2(x) in two pieces: log2(x) = w1 + w2, where w1
+//         has 53-24 = 29 bit trailing zeros.
+//      2. Perform y*log2(x) = n+y' by simulating muti-precision arithmetic,
+//         where |y'|<=0.5.
 //      3. Return x**y = 2**n*exp(y'*log2)
 //
 // Special cases:
-//      1.  (anything) ** 0  is 1
-//      2.  1 ** (anything)  is 1
-//      3.  (anything except 1) ** NAN is NAN
-//      4.  NAN ** (anything except 0) is NAN
-//      5.  +-(|x| > 1) **  +INF is +INF
-//      6.  +-(|x| > 1) **  -INF is +0
-//      7.  +-(|x| < 1) **  +INF is +0
-//      8.  +-(|x| < 1) **  -INF is +INF
-//      9.  -1          ** +-INF is 1
+//      1. (anything) ** 0  is 1
+//      2. 1 ** (anything)  is 1
+//      3. (anything except 1) ** NAN is NAN
+//      4. NAN ** (anything except 0) is NAN
+//      5. +-(|x| > 1) **  +INF is +INF
+//      6. +-(|x| > 1) **  -INF is +0
+//      7. +-(|x| < 1) **  +INF is +0
+//      8. +-(|x| < 1) **  -INF is +INF
+//      9. -1          ** +-INF is 1
 //      10. +0 ** (+anything except 0, NAN)               is +0
 //      11. -0 ** (+anything except 0, NAN, odd integer)  is +0
-//      12. +0 ** (-anything except 0, NAN)               is +INF, raise divbyzero
-//      13. -0 ** (-anything except 0, NAN, odd integer)  is +INF, raise divbyzero
+//      12. +0 ** (-anything except 0, NAN)               is +INF, raise
+//          divbyzero
+//      13. -0 ** (-anything except 0, NAN, odd integer)  is +INF, raise
+//          divbyzero
 //      14. -0 ** (+odd integer) is -0
 //      15. -0 ** (-odd integer) is -INF, raise divbyzero
 //      16. +INF ** (+anything except 0,NAN) is +INF
 //      17. +INF ** (-anything except 0,NAN) is +0
 //      18. -INF ** (+odd integer) is -INF
-//      19. -INF ** (anything) = -0 ** (-anything), (anything except odd integer)
+//      19. -INF ** (anything) = -0 ** (-anything), (anything except odd
+//          integer)
 //      20. (anything) ** 1 is (anything)
 //      21. (anything) ** -1 is 1/(anything)
 //      22. (-anything) ** (integer) is (-1)**(integer)*(+anything**integer)
@@ -619,10 +624,10 @@ pub fn powd(x: f64, y: f64) -> f64 {
     const OVT: f64 = 8.0085662595372944372e-017; /* -(1024-log2(ovfl+.5ulp)) */
     const CP: f64 = 9.61796693925975554329e-01; /* 0x3feec709_dc3a03fd =2/(3ln2) */
     const CP_H: f64 = 9.61796700954437255859e-01; /* 0x3feec709_e0000000 =(float)cp */
-    const CP_L: f64 = -7.02846165095275826516e-09; /* 0xbe3e2fe0_145b01f5 =tail of cp_h*/
+    const CP_L: f64 = -7.02846165095275826516e-09; /* 0xbe3e2fe0_145b01f5 =tail of cp_h */
     const IVLN2: f64 = 1.44269504088896338700e+00; /* 0x3ff71547_652b82fe =1/ln2 */
-    const IVLN2_H: f64 = 1.44269502162933349609e+00; /* 0x3ff71547_60000000 =24b 1/ln2*/
-    const IVLN2_L: f64 = 1.92596299112661746887e-08; /* 0x3e54ae0b_f85ddf44 =1/ln2 tail*/
+    const IVLN2_H: f64 = 1.44269502162933349609e+00; /* 0x3ff71547_60000000 =24b 1/ln2 */
+    const IVLN2_L: f64 = 1.92596299112661746887e-08; /* 0x3e54ae0b_f85ddf44 =1/ln2 tail */
 
     let t1: f64;
     let t2: f64;
@@ -834,7 +839,7 @@ pub fn powd(x: f64, y: f64) -> f64 {
             /* |x|<sqrt(3/2) */
             k = 0;
         } else if j < 0xBB67A {
-            /* |x|<sqrt(3)   */
+            /* |x|<sqrt(3) */
             k = 1;
         } else {
             k = 0;
@@ -1011,16 +1016,13 @@ pub fn scalbnd(x: f64, mut n: i32) -> f64 {
  *           ------------------------------------------
  * Method:
  *   Bit by bit method using integer arithmetic. (Slow, but portable)
- *   1. Normalization
- *      Scale x to y in [1,4) with even powers of 2:
- *      find an integer k such that  1 <= (y=x*2^(2k)) < 4, then
- *              sqrt(x) = 2^k * sqrt(y)
- *   2. Bit by bit computation
- *      Let q  = sqrt(y) truncated to i bit after binary point (q = 1),
- *           i                                                   0
- *                                     i+1         2
- *          s  = 2*q , and      y  =  2   * ( y - q  ).         (1)
- *           i      i            i                 i
+ *   1. Normalization Scale x to y in [1,4) with even powers of 2: find an
+ *      integer k such that  1 <= (y=x*2^(2k)) < 4, then sqrt(x) = 2^k *
+ *      sqrt(y)
+ *   2. Bit by bit computation Let q  = sqrt(y) truncated to i bit after
+ *      binary point (q = 1), i
+ *      0 i+1         2 s  = 2*q , and      y  =  2   * ( y - q  ).
+ *      (1) i      i            i                 i
  *
  *      To compute q    from q , one checks whether
  *                  i+1       i
@@ -1055,13 +1057,11 @@ pub fn scalbnd(x: f64, mut n: i32) -> f64 {
  *      Note. Since the left hand side of (3) contain only i+2 bits,
  *            it does not necessary to do a full (53-bit) comparison
  *            in (3).
- *   3. Final rounding
- *      After generating the 53 bits result, we compute one more bit.
- *      Together with the remainder, we can decide whether the
- *      result is exact, bigger than 1/2ulp, or less than 1/2ulp
- *      (it will never equal to 1/2ulp).
- *      The rounding mode can be detected by checking whether
- *      huge + tiny is equal to huge, and whether huge - tiny is
+ *   3. Final rounding After generating the 53 bits result, we compute one
+ *      more bit. Together with the remainder, we can decide whether the
+ *      result is exact, bigger than 1/2ulp, or less than 1/2ulp (it will
+ *      never equal to 1/2ulp). The rounding mode can be detected by checking
+ *      whether huge + tiny is equal to huge, and whether huge - tiny is
  *      equal to huge for some floating point number "huge" and "tiny".
  *
  * Special cases:
@@ -1116,7 +1116,8 @@ pub fn sqrtd(x: f64) -> f64 {
 
         /* take care of Inf and NaN */
         if (ix0 & 0x7ff00000) == 0x7ff00000 {
-            return x * x + x; /* sqrt(NaN)=NaN, sqrt(+inf)=+inf, sqrt(-inf)=sNaN */
+            return x * x + x; /* sqrt(NaN)=NaN, sqrt(+inf)=+inf,
+                               * sqrt(-inf)=sNaN */
         }
         /* take care of zero */
         if ix0 <= 0 {

--- a/lexical-parse-float/src/limits.rs
+++ b/lexical-parse-float/src/limits.rs
@@ -101,89 +101,14 @@ impl ExactFloat for bf16 {
 //    #[inline(always)]
 //    fn exponent_limit(radix: u32) -> (i64, i64) {
 //        debug_assert_radix(radix);
-//        match radix {
-//            2 if cfg!(feature = "power-of-two") => (-16494, 16383),
-//            3 if cfg!(feature = "radix") => (-71, 71),
-//            4 if cfg!(feature = "power-of-two") => (-8247, 8191),
-//            5 if cfg!(feature = "radix") => (-48, 48),
-//            6 if cfg!(feature = "radix") => (-71, 71),
-//            7 if cfg!(feature = "radix") => (-40, 40),
-//            8 if cfg!(feature = "power-of-two") => (-5498, 5461),
-//            9 if cfg!(feature = "radix") => (-35, 35),
-//            10 => (-48, 48),
-//            11 if cfg!(feature = "radix") => (-32, 32),
-//            12 if cfg!(feature = "radix") => (-71, 71),
-//            13 if cfg!(feature = "radix") => (-30, 30),
-//            14 if cfg!(feature = "radix") => (-40, 40),
-//            15 if cfg!(feature = "radix") => (-28, 28),
-//            16 if cfg!(feature = "power-of-two") => (-4123, 4095),
-//            17 if cfg!(feature = "radix") => (-27, 27),
-//            18 if cfg!(feature = "radix") => (-35, 35),
-//            19 if cfg!(feature = "radix") => (-26, 26),
-//            20 if cfg!(feature = "radix") => (-48, 48),
-//            21 if cfg!(feature = "radix") => (-25, 25),
-//            22 if cfg!(feature = "radix") => (-32, 32),
-//            23 if cfg!(feature = "radix") => (-24, 24),
-//            24 if cfg!(feature = "radix") => (-71, 71),
-//            25 if cfg!(feature = "radix") => (-24, 24),
-//            26 if cfg!(feature = "radix") => (-30, 30),
-//            27 if cfg!(feature = "radix") => (-23, 23),
-//            28 if cfg!(feature = "radix") => (-40, 40),
-//            29 if cfg!(feature = "radix") => (-23, 23),
-//            30 if cfg!(feature = "radix") => (-28, 28),
-//            31 if cfg!(feature = "radix") => (-22, 22),
-//            32 if cfg!(feature = "power-of-two") => (-3298, 3276),
-//            33 if cfg!(feature = "radix") => (-22, 22),
-//            34 if cfg!(feature = "radix") => (-27, 27),
-//            35 if cfg!(feature = "radix") => (-22, 22),
-//            36 if cfg!(feature = "radix") => (-35, 35),
-//            // Invalid radix
-//            _ => unreachable!(),
+//        f128_exponent_limit(radix)
 //        }
 //    }
 //
 //    #[inline(always)]
 //    fn mantissa_limit(radix: u32) -> i64 {
 //        debug_assert_radix(radix);
-//        match radix {
-//            2 if cfg!(feature = "power-of-two") => 113,
-//            3 if cfg!(feature = "radix") => 71,
-//            4 if cfg!(feature = "power-of-two") => 56,
-//            5 if cfg!(feature = "radix") => 48,
-//            6 if cfg!(feature = "radix") => 43,
-//            7 if cfg!(feature = "radix") => 40,
-//            8 if cfg!(feature = "power-of-two") => 37,
-//            9 if cfg!(feature = "radix") => 35,
-//            10 => 34,
-//            11 if cfg!(feature = "radix") => 32,
-//            12 if cfg!(feature = "radix") => 31,
-//            13 if cfg!(feature = "radix") => 30,
-//            14 if cfg!(feature = "radix") => 29,
-//            15 if cfg!(feature = "radix") => 28,
-//            16 if cfg!(feature = "power-of-two") => 28,
-//            17 if cfg!(feature = "radix") => 27,
-//            18 if cfg!(feature = "radix") => 27,
-//            19 if cfg!(feature = "radix") => 26,
-//            20 if cfg!(feature = "radix") => 26,
-//            21 if cfg!(feature = "radix") => 25,
-//            22 if cfg!(feature = "radix") => 25,
-//            23 if cfg!(feature = "radix") => 24,
-//            24 if cfg!(feature = "radix") => 24,
-//            25 if cfg!(feature = "radix") => 24,
-//            26 if cfg!(feature = "radix") => 24,
-//            27 if cfg!(feature = "radix") => 23,
-//            28 if cfg!(feature = "radix") => 23,
-//            29 if cfg!(feature = "radix") => 23,
-//            30 if cfg!(feature = "radix") => 23,
-//            31 if cfg!(feature = "radix") => 22,
-//            32 if cfg!(feature = "power-of-two") => 22,
-//            33 if cfg!(feature = "radix") => 22,
-//            34 if cfg!(feature = "radix") => 22,
-//            35 if cfg!(feature = "radix") => 22,
-//            36 if cfg!(feature = "radix") => 21,
-//            // Invalid radix
-//            _ => unreachable!(),
-//        }
+//        f128_mantissa_limit(radix)
 //    }
 //}
 
@@ -192,172 +117,426 @@ impl ExactFloat for bf16 {
 
 /// Get the exponent limit as a const fn.
 #[inline(always)]
+#[cfg(feature = "radix")]
 pub const fn f32_exponent_limit(radix: u32) -> (i64, i64) {
     match radix {
-        2 if cfg!(feature = "power-of-two") => (-127, 127),
-        3 if cfg!(feature = "radix") => (-15, 15),
-        4 if cfg!(feature = "power-of-two") => (-63, 63),
-        5 if cfg!(feature = "radix") => (-10, 10),
-        6 if cfg!(feature = "radix") => (-15, 15),
-        7 if cfg!(feature = "radix") => (-8, 8),
-        8 if cfg!(feature = "power-of-two") => (-42, 42),
-        9 if cfg!(feature = "radix") => (-7, 7),
+        2 => (-127, 127),
+        3 => (-15, 15),
+        4 => (-63, 63),
+        5 => (-10, 10),
+        6 => (-15, 15),
+        7 => (-8, 8),
+        8 => (-42, 42),
+        9 => (-7, 7),
         10 => (-10, 10),
-        11 if cfg!(feature = "radix") => (-6, 6),
-        12 if cfg!(feature = "radix") => (-15, 15),
-        13 if cfg!(feature = "radix") => (-6, 6),
-        14 if cfg!(feature = "radix") => (-8, 8),
-        15 if cfg!(feature = "radix") => (-6, 6),
-        16 if cfg!(feature = "power-of-two") => (-31, 31),
-        17 if cfg!(feature = "radix") => (-5, 5),
-        18 if cfg!(feature = "radix") => (-7, 7),
-        19 if cfg!(feature = "radix") => (-5, 5),
-        20 if cfg!(feature = "radix") => (-10, 10),
-        21 if cfg!(feature = "radix") => (-5, 5),
-        22 if cfg!(feature = "radix") => (-6, 6),
-        23 if cfg!(feature = "radix") => (-5, 5),
-        24 if cfg!(feature = "radix") => (-15, 15),
-        25 if cfg!(feature = "radix") => (-5, 5),
-        26 if cfg!(feature = "radix") => (-6, 6),
-        27 if cfg!(feature = "radix") => (-5, 5),
-        28 if cfg!(feature = "radix") => (-8, 8),
-        29 if cfg!(feature = "radix") => (-4, 4),
-        30 if cfg!(feature = "radix") => (-6, 6),
-        31 if cfg!(feature = "radix") => (-4, 4),
-        32 if cfg!(feature = "power-of-two") => (-25, 25),
-        33 if cfg!(feature = "radix") => (-4, 4),
-        34 if cfg!(feature = "radix") => (-5, 5),
-        35 if cfg!(feature = "radix") => (-4, 4),
-        36 if cfg!(feature = "radix") => (-7, 7),
+        11 => (-6, 6),
+        12 => (-15, 15),
+        13 => (-6, 6),
+        14 => (-8, 8),
+        15 => (-6, 6),
+        16 => (-31, 31),
+        17 => (-5, 5),
+        18 => (-7, 7),
+        19 => (-5, 5),
+        20 => (-10, 10),
+        21 => (-5, 5),
+        22 => (-6, 6),
+        23 => (-5, 5),
+        24 => (-15, 15),
+        25 => (-5, 5),
+        26 => (-6, 6),
+        27 => (-5, 5),
+        28 => (-8, 8),
+        29 => (-4, 4),
+        30 => (-6, 6),
+        31 => (-4, 4),
+        32 => (-25, 25),
+        33 => (-4, 4),
+        34 => (-5, 5),
+        35 => (-4, 4),
+        36 => (-7, 7),
+        _ => (0, 0),
+    }
+}
+
+/// Get the exponent limit as a const fn.
+#[inline(always)]
+#[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+pub const fn f32_exponent_limit(radix: u32) -> (i64, i64) {
+    match radix {
+        2 => (-127, 127),
+        4 => (-63, 63),
+        8 => (-42, 42),
+        10 => (-10, 10),
+        16 => (-31, 31),
+        32 => (-25, 25),
+        _ => (0, 0),
+    }
+}
+
+/// Get the exponent limit as a const fn.
+#[inline(always)]
+#[cfg(not(feature = "power-of-two"))]
+pub const fn f32_exponent_limit(radix: u32) -> (i64, i64) {
+    match radix {
+        10 => (-10, 10),
         _ => (0, 0),
     }
 }
 
 /// Get the mantissa limit as a const fn.
 #[inline(always)]
+#[cfg(feature = "radix")]
 pub const fn f32_mantissa_limit(radix: u32) -> i64 {
     match radix {
-        2 if cfg!(feature = "power-of-two") => 24,
-        3 if cfg!(feature = "radix") => 15,
-        4 if cfg!(feature = "power-of-two") => 12,
-        5 if cfg!(feature = "radix") => 10,
-        6 if cfg!(feature = "radix") => 9,
-        7 if cfg!(feature = "radix") => 8,
-        8 if cfg!(feature = "power-of-two") => 8,
-        9 if cfg!(feature = "radix") => 7,
+        2 => 24,
+        3 => 15,
+        4 => 12,
+        5 => 10,
+        6 => 9,
+        7 => 8,
+        8 => 8,
+        9 => 7,
         10 => 7,
-        11 if cfg!(feature = "radix") => 6,
-        12 if cfg!(feature = "radix") => 6,
-        13 if cfg!(feature = "radix") => 6,
-        14 if cfg!(feature = "radix") => 6,
-        15 if cfg!(feature = "radix") => 6,
-        16 if cfg!(feature = "power-of-two") => 6,
-        17 if cfg!(feature = "radix") => 5,
-        18 if cfg!(feature = "radix") => 5,
-        19 if cfg!(feature = "radix") => 5,
-        20 if cfg!(feature = "radix") => 5,
-        21 if cfg!(feature = "radix") => 5,
-        22 if cfg!(feature = "radix") => 5,
-        23 if cfg!(feature = "radix") => 5,
-        24 if cfg!(feature = "radix") => 5,
-        25 if cfg!(feature = "radix") => 5,
-        26 if cfg!(feature = "radix") => 5,
-        27 if cfg!(feature = "radix") => 5,
-        28 if cfg!(feature = "radix") => 4,
-        29 if cfg!(feature = "radix") => 4,
-        30 if cfg!(feature = "radix") => 4,
-        31 if cfg!(feature = "radix") => 4,
-        32 if cfg!(feature = "power-of-two") => 4,
-        33 if cfg!(feature = "radix") => 4,
-        34 if cfg!(feature = "radix") => 4,
-        35 if cfg!(feature = "radix") => 4,
-        36 if cfg!(feature = "radix") => 4,
+        11 => 6,
+        12 => 6,
+        13 => 6,
+        14 => 6,
+        15 => 6,
+        16 => 6,
+        17 => 5,
+        18 => 5,
+        19 => 5,
+        20 => 5,
+        21 => 5,
+        22 => 5,
+        23 => 5,
+        24 => 5,
+        25 => 5,
+        26 => 5,
+        27 => 5,
+        28 => 4,
+        29 => 4,
+        30 => 4,
+        31 => 4,
+        32 => 4,
+        33 => 4,
+        34 => 4,
+        35 => 4,
+        36 => 4,
+        _ => 0,
+    }
+}
+
+/// Get the mantissa limit as a const fn.
+#[inline(always)]
+#[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+pub const fn f32_mantissa_limit(radix: u32) -> i64 {
+    match radix {
+        2 => 24,
+        4 => 12,
+        8 => 8,
+        10 => 7,
+        16 => 6,
+        32 => 4,
+        _ => 0,
+    }
+}
+
+/// Get the mantissa limit as a const fn.
+#[inline(always)]
+#[cfg(not(feature = "power-of-two"))]
+pub const fn f32_mantissa_limit(radix: u32) -> i64 {
+    match radix {
+        10 => 7,
         _ => 0,
     }
 }
 
 /// Get the exponent limit as a const fn.
 #[inline(always)]
+#[cfg(feature = "radix")]
 pub const fn f64_exponent_limit(radix: u32) -> (i64, i64) {
     match radix {
-        2 if cfg!(feature = "power-of-two") => (-1023, 1023),
-        3 if cfg!(feature = "radix") => (-33, 33),
-        4 if cfg!(feature = "power-of-two") => (-511, 511),
-        5 if cfg!(feature = "radix") => (-22, 22),
-        6 if cfg!(feature = "radix") => (-33, 33),
-        7 if cfg!(feature = "radix") => (-18, 18),
-        8 if cfg!(feature = "power-of-two") => (-341, 341),
-        9 if cfg!(feature = "radix") => (-16, 16),
+        2 => (-1023, 1023),
+        3 => (-33, 33),
+        4 => (-511, 511),
+        5 => (-22, 22),
+        6 => (-33, 33),
+        7 => (-18, 18),
+        8 => (-341, 341),
+        9 => (-16, 16),
         10 => (-22, 22),
-        11 if cfg!(feature = "radix") => (-15, 15),
-        12 if cfg!(feature = "radix") => (-33, 33),
-        13 if cfg!(feature = "radix") => (-14, 14),
-        14 if cfg!(feature = "radix") => (-18, 18),
-        15 if cfg!(feature = "radix") => (-13, 13),
-        16 if cfg!(feature = "power-of-two") => (-255, 255),
-        17 if cfg!(feature = "radix") => (-12, 12),
-        18 if cfg!(feature = "radix") => (-16, 16),
-        19 if cfg!(feature = "radix") => (-12, 12),
-        20 if cfg!(feature = "radix") => (-22, 22),
-        21 if cfg!(feature = "radix") => (-12, 12),
-        22 if cfg!(feature = "radix") => (-15, 15),
-        23 if cfg!(feature = "radix") => (-11, 11),
-        24 if cfg!(feature = "radix") => (-33, 33),
-        25 if cfg!(feature = "radix") => (-11, 11),
-        26 if cfg!(feature = "radix") => (-14, 14),
-        27 if cfg!(feature = "radix") => (-11, 11),
-        28 if cfg!(feature = "radix") => (-18, 18),
-        29 if cfg!(feature = "radix") => (-10, 10),
-        30 if cfg!(feature = "radix") => (-13, 13),
-        31 if cfg!(feature = "radix") => (-10, 10),
-        32 if cfg!(feature = "power-of-two") => (-204, 204),
-        33 if cfg!(feature = "radix") => (-10, 10),
-        34 if cfg!(feature = "radix") => (-12, 12),
-        35 if cfg!(feature = "radix") => (-10, 10),
-        36 if cfg!(feature = "radix") => (-16, 16),
+        11 => (-15, 15),
+        12 => (-33, 33),
+        13 => (-14, 14),
+        14 => (-18, 18),
+        15 => (-13, 13),
+        16 => (-255, 255),
+        17 => (-12, 12),
+        18 => (-16, 16),
+        19 => (-12, 12),
+        20 => (-22, 22),
+        21 => (-12, 12),
+        22 => (-15, 15),
+        23 => (-11, 11),
+        24 => (-33, 33),
+        25 => (-11, 11),
+        26 => (-14, 14),
+        27 => (-11, 11),
+        28 => (-18, 18),
+        29 => (-10, 10),
+        30 => (-13, 13),
+        31 => (-10, 10),
+        32 => (-204, 204),
+        33 => (-10, 10),
+        34 => (-12, 12),
+        35 => (-10, 10),
+        36 => (-16, 16),
+        _ => (0, 0),
+    }
+}
+
+// Get the exponent limit as a const fn.
+#[inline(always)]
+#[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+pub const fn f64_exponent_limit(radix: u32) -> (i64, i64) {
+    match radix {
+        2 => (-1023, 1023),
+        4 => (-511, 511),
+        8 => (-341, 341),
+        10 => (-22, 22),
+        16 => (-255, 255),
+        32 => (-204, 204),
+        _ => (0, 0),
+    }
+}
+
+/// Get the exponent limit as a const fn.
+#[cfg(not(feature = "power-of-two"))]
+#[inline(always)]
+pub const fn f64_exponent_limit(radix: u32) -> (i64, i64) {
+    match radix {
+        10 => (-22, 22),
         _ => (0, 0),
     }
 }
 
 /// Get the mantissa limit as a const fn.
 #[inline(always)]
+#[cfg(feature = "radix")]
 pub const fn f64_mantissa_limit(radix: u32) -> i64 {
     match radix {
-        2 if cfg!(feature = "power-of-two") => 53,
-        3 if cfg!(feature = "radix") => 33,
-        4 if cfg!(feature = "power-of-two") => 26,
-        5 if cfg!(feature = "radix") => 22,
-        6 if cfg!(feature = "radix") => 20,
-        7 if cfg!(feature = "radix") => 18,
-        8 if cfg!(feature = "power-of-two") => 17,
-        9 if cfg!(feature = "radix") => 16,
+        2 => 53,
+        3 => 33,
+        4 => 26,
+        5 => 22,
+        6 => 20,
+        7 => 18,
+        8 => 17,
+        9 => 16,
         10 => 15,
-        11 if cfg!(feature = "radix") => 15,
-        12 if cfg!(feature = "radix") => 14,
-        13 if cfg!(feature = "radix") => 14,
-        14 if cfg!(feature = "radix") => 13,
-        15 if cfg!(feature = "radix") => 13,
-        16 if cfg!(feature = "power-of-two") => 13,
-        17 if cfg!(feature = "radix") => 12,
-        18 if cfg!(feature = "radix") => 12,
-        19 if cfg!(feature = "radix") => 12,
-        20 if cfg!(feature = "radix") => 12,
-        21 if cfg!(feature = "radix") => 12,
-        22 if cfg!(feature = "radix") => 11,
-        23 if cfg!(feature = "radix") => 11,
-        24 if cfg!(feature = "radix") => 11,
-        25 if cfg!(feature = "radix") => 11,
-        26 if cfg!(feature = "radix") => 11,
-        27 if cfg!(feature = "radix") => 11,
-        28 if cfg!(feature = "radix") => 11,
-        29 if cfg!(feature = "radix") => 10,
-        30 if cfg!(feature = "radix") => 10,
-        31 if cfg!(feature = "radix") => 10,
-        32 if cfg!(feature = "power-of-two") => 10,
-        33 if cfg!(feature = "radix") => 10,
-        34 if cfg!(feature = "radix") => 10,
-        35 if cfg!(feature = "radix") => 10,
-        36 if cfg!(feature = "radix") => 10,
+        11 => 15,
+        12 => 14,
+        13 => 14,
+        14 => 13,
+        15 => 13,
+        16 => 13,
+        17 => 12,
+        18 => 12,
+        19 => 12,
+        20 => 12,
+        21 => 12,
+        22 => 11,
+        23 => 11,
+        24 => 11,
+        25 => 11,
+        26 => 11,
+        27 => 11,
+        28 => 11,
+        29 => 10,
+        30 => 10,
+        31 => 10,
+        32 => 10,
+        33 => 10,
+        34 => 10,
+        35 => 10,
+        36 => 10,
+        _ => 0,
+    }
+}
+
+/// Get the mantissa limit as a const fn.
+#[inline(always)]
+#[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+pub const fn f64_mantissa_limit(radix: u32) -> i64 {
+    match radix {
+        2 => 53,
+        4 => 26,
+        8 => 17,
+        10 => 15,
+        16 => 13,
+        32 => 10,
+        _ => 0,
+    }
+}
+
+/// Get the mantissa limit as a const fn.
+#[inline(always)]
+#[cfg(not(feature = "power-of-two"))]
+pub const fn f64_mantissa_limit(radix: u32) -> i64 {
+    match radix {
+        10 => 15,
+        _ => 0,
+    }
+}
+
+/// Get the exponent limit as a const fn.
+#[inline(always)]
+#[cfg(feature = "f128")]
+#[cfg(feature = "radix")]
+pub const fn f128_exponent_limit(radix: u32) -> (i64, i64) {
+    match radix {
+        2 => (-16494, 16383),
+        3 => (-71, 71),
+        4 => (-8247, 8191),
+        5 => (-48, 48),
+        6 => (-71, 71),
+        7 => (-40, 40),
+        8 => (-5498, 5461),
+        9 => (-35, 35),
+        10 => (-48, 48),
+        11 => (-32, 32),
+        12 => (-71, 71),
+        13 => (-30, 30),
+        14 => (-40, 40),
+        15 => (-28, 28),
+        16 => (-4123, 4095),
+        17 => (-27, 27),
+        18 => (-35, 35),
+        19 => (-26, 26),
+        20 => (-48, 48),
+        21 => (-25, 25),
+        22 => (-32, 32),
+        23 => (-24, 24),
+        24 => (-71, 71),
+        25 => (-24, 24),
+        26 => (-30, 30),
+        27 => (-23, 23),
+        28 => (-40, 40),
+        29 => (-23, 23),
+        30 => (-28, 28),
+        31 => (-22, 22),
+        32 => (-3298, 3276),
+        33 => (-22, 22),
+        34 => (-27, 27),
+        35 => (-22, 22),
+        36 => (-35, 35),
+        // Invalid radix
+        _ => (0, 0),
+    }
+}
+
+/// Get the exponent limit as a const fn.
+#[inline(always)]
+#[cfg(feature = "f128")]
+#[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+pub const fn f128_exponent_limit(radix: u32) -> (i64, i64) {
+    match radix {
+        2 => (-16494, 16383),
+        4 => (-8247, 8191),
+        8 => (-5498, 5461),
+        10 => (-48, 48),
+        16 => (-4123, 4095),
+        32 => (-3298, 3276),
+        // Invalid radix
+        _ => (0, 0),
+    }
+}
+
+/// Get the exponent limit as a const fn.
+#[inline(always)]
+#[cfg(feature = "f128")]
+#[cfg(not(feature = "power-of-two"))]
+pub const fn f128_exponent_limit(radix: u32) -> (i64, i64) {
+    match radix {
+        10 => (-48, 48),
+        // Invalid radix
+        _ => (0, 0),
+    }
+}
+
+/// Get the mantissa limit as a const fn.
+#[inline(always)]
+#[cfg(feature = "f128")]
+#[cfg(feature = "radix")]
+pub const fn f128_mantissa_limit(radix: u32) -> i64 {
+    match radix {
+        2 => 113,
+        3 => 71,
+        4 => 56,
+        5 => 48,
+        6 => 43,
+        7 => 40,
+        8 => 37,
+        9 => 35,
+        10 => 34,
+        11 => 32,
+        12 => 31,
+        13 => 30,
+        14 => 29,
+        15 => 28,
+        16 => 28,
+        17 => 27,
+        18 => 27,
+        19 => 26,
+        20 => 26,
+        21 => 25,
+        22 => 25,
+        23 => 24,
+        24 => 24,
+        25 => 24,
+        26 => 24,
+        27 => 23,
+        28 => 23,
+        29 => 23,
+        30 => 23,
+        31 => 22,
+        32 => 22,
+        33 => 22,
+        34 => 22,
+        35 => 22,
+        36 => 21,
+        // Invalid radix
+        _ => 0,
+    }
+}
+
+/// Get the mantissa limit as a const fn.
+#[inline(always)]
+#[cfg(feature = "f128")]
+#[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+pub const fn f128_mantissa_limit(radix: u32) -> i64 {
+    match radix {
+        2 => 113,
+        4 => 56,
+        8 => 37,
+        10 => 34,
+        16 => 28,
+        32 => 22,
+        // Invalid radix
+        _ => 0,
+    }
+}
+
+/// Get the mantissa limit as a const fn.
+#[inline(always)]
+#[cfg(feature = "f128")]
+#[cfg(not(feature = "power-of-two"))]
+pub const fn f128_mantissa_limit(radix: u32) -> i64 {
+    match radix {
+        10 => 34,
+        // Invalid radix
         _ => 0,
     }
 }
@@ -399,43 +578,73 @@ pub const fn f64_mantissa_limit(radix: u32) -> i64 {
 /// Get the maximum value for `radix^N` that can be represented in a u32.
 /// This is calculated as `⌊log(2^32 - 1, b)⌋`.
 #[inline(always)]
+#[cfg(feature = "radix")]
 pub const fn u32_power_limit(radix: u32) -> u32 {
     match radix {
-        2 if cfg!(feature = "power-of-two") => 31,
-        3 if cfg!(feature = "radix") => 20,
-        4 if cfg!(feature = "power-of-two") => 15,
+        2 => 31,
+        3 => 20,
+        4 => 15,
         5 => 13,
-        6 if cfg!(feature = "radix") => 12,
-        7 if cfg!(feature = "radix") => 11,
-        8 if cfg!(feature = "power-of-two") => 10,
-        9 if cfg!(feature = "radix") => 10,
+        6 => 12,
+        7 => 11,
+        8 => 10,
+        9 => 10,
         10 => 9,
-        11 if cfg!(feature = "radix") => 9,
-        12 if cfg!(feature = "radix") => 8,
-        13 if cfg!(feature = "radix") => 8,
-        14 if cfg!(feature = "radix") => 8,
-        15 if cfg!(feature = "radix") => 8,
-        16 if cfg!(feature = "power-of-two") => 7,
-        17 if cfg!(feature = "radix") => 7,
-        18 if cfg!(feature = "radix") => 7,
-        19 if cfg!(feature = "radix") => 7,
-        20 if cfg!(feature = "radix") => 7,
-        21 if cfg!(feature = "radix") => 7,
-        22 if cfg!(feature = "radix") => 7,
-        23 if cfg!(feature = "radix") => 7,
-        24 if cfg!(feature = "radix") => 6,
-        25 if cfg!(feature = "radix") => 6,
-        26 if cfg!(feature = "radix") => 6,
-        27 if cfg!(feature = "radix") => 6,
-        28 if cfg!(feature = "radix") => 6,
-        29 if cfg!(feature = "radix") => 6,
-        30 if cfg!(feature = "radix") => 6,
-        31 if cfg!(feature = "radix") => 6,
-        32 if cfg!(feature = "power-of-two") => 6,
-        33 if cfg!(feature = "radix") => 6,
-        34 if cfg!(feature = "radix") => 6,
-        35 if cfg!(feature = "radix") => 6,
-        36 if cfg!(feature = "radix") => 6,
+        11 => 9,
+        12 => 8,
+        13 => 8,
+        14 => 8,
+        15 => 8,
+        16 => 7,
+        17 => 7,
+        18 => 7,
+        19 => 7,
+        20 => 7,
+        21 => 7,
+        22 => 7,
+        23 => 7,
+        24 => 6,
+        25 => 6,
+        26 => 6,
+        27 => 6,
+        28 => 6,
+        29 => 6,
+        30 => 6,
+        31 => 6,
+        32 => 6,
+        33 => 6,
+        34 => 6,
+        35 => 6,
+        36 => 6,
+        // Any other radix should be unreachable.
+        _ => 1,
+    }
+}
+
+/// This is calculated as `⌊log(2^32 - 1, b)⌋`.
+#[inline(always)]
+#[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+pub const fn u32_power_limit(radix: u32) -> u32 {
+    match radix {
+        2 => 31,
+        4 => 15,
+        5 => 13,
+        8 => 10,
+        10 => 9,
+        16 => 7,
+        32 => 6,
+        // Any other radix should be unreachable.
+        _ => 1,
+    }
+}
+
+/// This is calculated as `⌊log(2^32 - 1, b)⌋`.
+#[inline(always)]
+#[cfg(not(feature = "power-of-two"))]
+pub const fn u32_power_limit(radix: u32) -> u32 {
+    match radix {
+        5 => 13,
+        10 => 9,
         // Any other radix should be unreachable.
         _ => 1,
     }
@@ -444,43 +653,73 @@ pub const fn u32_power_limit(radix: u32) -> u32 {
 /// Get the maximum value for `radix^N` that can be represented in a u64.
 /// This is calculated as `⌊log(2^64 - 1, b)⌋`.
 #[inline(always)]
+#[cfg(feature = "radix")]
 pub const fn u64_power_limit(radix: u32) -> u32 {
     match radix {
-        2 if cfg!(feature = "power-of-two") => 63,
-        3 if cfg!(feature = "radix") => 40,
-        4 if cfg!(feature = "power-of-two") => 31,
+        2 => 63,
+        3 => 40,
+        4 => 31,
         5 => 27,
-        6 if cfg!(feature = "radix") => 24,
-        7 if cfg!(feature = "radix") => 22,
-        8 if cfg!(feature = "power-of-two") => 21,
-        9 if cfg!(feature = "radix") => 20,
+        6 => 24,
+        7 => 22,
+        8 => 21,
+        9 => 20,
         10 => 19,
-        11 if cfg!(feature = "radix") => 18,
-        12 if cfg!(feature = "radix") => 17,
-        13 if cfg!(feature = "radix") => 17,
-        14 if cfg!(feature = "radix") => 16,
-        15 if cfg!(feature = "radix") => 16,
-        16 if cfg!(feature = "power-of-two") => 15,
-        17 if cfg!(feature = "radix") => 15,
-        18 if cfg!(feature = "radix") => 15,
-        19 if cfg!(feature = "radix") => 15,
-        20 if cfg!(feature = "radix") => 14,
-        21 if cfg!(feature = "radix") => 14,
-        22 if cfg!(feature = "radix") => 14,
-        23 if cfg!(feature = "radix") => 14,
-        24 if cfg!(feature = "radix") => 13,
-        25 if cfg!(feature = "radix") => 13,
-        26 if cfg!(feature = "radix") => 13,
-        27 if cfg!(feature = "radix") => 13,
-        28 if cfg!(feature = "radix") => 13,
-        29 if cfg!(feature = "radix") => 13,
-        30 if cfg!(feature = "radix") => 13,
-        31 if cfg!(feature = "radix") => 12,
-        32 if cfg!(feature = "power-of-two") => 12,
-        33 if cfg!(feature = "radix") => 12,
-        34 if cfg!(feature = "radix") => 12,
-        35 if cfg!(feature = "radix") => 12,
-        36 if cfg!(feature = "radix") => 12,
+        11 => 18,
+        12 => 17,
+        13 => 17,
+        14 => 16,
+        15 => 16,
+        16 => 15,
+        17 => 15,
+        18 => 15,
+        19 => 15,
+        20 => 14,
+        21 => 14,
+        22 => 14,
+        23 => 14,
+        24 => 13,
+        25 => 13,
+        26 => 13,
+        27 => 13,
+        28 => 13,
+        29 => 13,
+        30 => 13,
+        31 => 12,
+        32 => 12,
+        33 => 12,
+        34 => 12,
+        35 => 12,
+        36 => 12,
+        // Any other radix should be unreachable.
+        _ => 1,
+    }
+}
+
+/// Get the maximum value for `radix^N` that can be represented in a u64.
+/// This is calculated as `⌊log(2^64 - 1, b)⌋`.
+#[inline(always)]
+#[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+pub const fn u64_power_limit(radix: u32) -> u32 {
+    match radix {
+        2 => 63,
+        4 => 31,
+        5 => 27,
+        8 => 21,
+        10 => 19,
+        16 => 15,
+        32 => 12,
+        // Any other radix should be unreachable.
+        _ => 1,
+    }
+}
+
+#[inline(always)]
+#[cfg(not(feature = "power-of-two"))]
+pub const fn u64_power_limit(radix: u32) -> u32 {
+    match radix {
+        5 => 27,
+        10 => 19,
         // Any other radix should be unreachable.
         _ => 1,
     }

--- a/lexical-parse-float/src/limits.rs
+++ b/lexical-parse-float/src/limits.rs
@@ -498,7 +498,8 @@ pub const fn u64_power_limit(radix: u32) -> u32 {
 /// digits required to exactly represent that float. This makes sense,
 /// and the exact reference and I quote is:
 ///
-///  > A necessary and sufficient condition for all numbers representable in radix β
+///  > A necessary and sufficient condition for all numbers representable in
+///  > radix β
 ///  > with a finite number of digits to be representable in radix γ with a
 ///  > finite number of digits is that β should divide an integer power of γ.
 ///
@@ -529,7 +530,8 @@ pub const fn u64_power_limit(radix: u32) -> u32 {
 ///     p2 = 113
 ///
 /// In Python:
-///     `-emin + p2 + math.floor((emin+ 1)*math.log(2, b)-math.log(1-2**(-p2), b))`
+///     `-emin + p2 + math.floor((emin+ 1)*math.log(2, b)-math.log(1-2**(-p2),
+/// b))`
 ///
 /// This was used to calculate the maximum number of digits for [2, 36].
 ///

--- a/lexical-parse-float/src/number.rs
+++ b/lexical-parse-float/src/number.rs
@@ -2,14 +2,14 @@
 //!
 //! This is adapted from [fast-float-rust](https://github.com/aldanor/fast-float-rust),
 //! a port of [fast_float](https://github.com/fastfloat/fast_float) to Rust.
-//!
 
 #![doc(hidden)]
+
+use lexical_util::format::NumberFormat;
 
 use crate::float::RawFloat;
 #[cfg(feature = "nightly")]
 use crate::fpu::set_precision;
-use lexical_util::format::NumberFormat;
 
 /// Representation of a number as the significant digits and exponent.
 ///
@@ -46,10 +46,10 @@ impl<'a> Number<'a> {
 
     /// The fast path algorithmn using machine-sized integers and floats.
     ///
-    /// This is extracted into a separate function so that it can be attempted before constructing
-    /// a Decimal. This only works if both the mantissa and the exponent
-    /// can be exactly represented as a machine float, since IEE-754 guarantees
-    /// no rounding will occur.
+    /// This is extracted into a separate function so that it can be attempted
+    /// before constructing a Decimal. This only works if both the mantissa
+    /// and the exponent can be exactly represented as a machine float,
+    /// since IEE-754 guarantees no rounding will occur.
     ///
     /// There is an exception: disguised fast-path cases, where we can shift
     /// powers-of-10 from the exponent to the significant digits.
@@ -58,11 +58,13 @@ impl<'a> Number<'a> {
     pub fn try_fast_path<F: RawFloat, const FORMAT: u128>(&self) -> Option<F> {
         let format = NumberFormat::<FORMAT> {};
         debug_assert!(format.mantissa_radix() == format.exponent_base());
-        // The fast path crucially depends on arithmetic being rounded to the correct number of bits
-        // without any intermediate rounding. On x86 (without SSE or SSE2) this requires the precision
-        // of the x87 FPU stack to be changed so that it directly rounds to 64/32 bit.
-        // The `set_precision` function takes care of setting the precision on architectures which
-        // require setting it by changing the global state (like the control word of the x87 FPU).
+        // The fast path crucially depends on arithmetic being rounded to the correct
+        // number of bits without any intermediate rounding. On x86 (without SSE
+        // or SSE2) this requires the precision of the x87 FPU stack to be
+        // changed so that it directly rounds to 64/32 bit. The `set_precision`
+        // function takes care of setting the precision on architectures which
+        // require setting it by changing the global state (like the control word of the
+        // x87 FPU).
         #[cfg(feature = "nightly")]
         let _cw = set_precision::<F>();
 

--- a/lexical-parse-float/src/parse.rs
+++ b/lexical-parse-float/src/parse.rs
@@ -9,17 +9,6 @@
 
 #![doc(hidden)]
 
-#[cfg(any(feature = "compact", feature = "radix"))]
-use crate::bellerophon::bellerophon;
-#[cfg(feature = "power-of-two")]
-use crate::binary::{binary, slow_binary};
-use crate::float::{extended_to_float, ExtendedFloat80, LemireFloat};
-#[cfg(not(feature = "compact"))]
-use crate::lemire::lemire;
-use crate::number::Number;
-use crate::options::Options;
-use crate::shared;
-use crate::slow::slow_radix;
 #[cfg(not(feature = "compact"))]
 use lexical_parse_integer::algorithm;
 #[cfg(feature = "f16")]
@@ -33,6 +22,18 @@ use lexical_util::format::NumberFormat;
 use lexical_util::iterator::{AsBytes, Bytes, BytesIter};
 use lexical_util::result::Result;
 use lexical_util::step::u64_step;
+
+#[cfg(any(feature = "compact", feature = "radix"))]
+use crate::bellerophon::bellerophon;
+#[cfg(feature = "power-of-two")]
+use crate::binary::{binary, slow_binary};
+use crate::float::{extended_to_float, ExtendedFloat80, LemireFloat};
+#[cfg(not(feature = "compact"))]
+use crate::lemire::lemire;
+use crate::number::Number;
+use crate::options::Options;
+use crate::shared;
+use crate::slow::slow_radix;
 
 // API
 // ---
@@ -87,14 +88,16 @@ pub trait ParseFloat: LemireFloat {
         parse_partial::<Self, FORMAT>(bytes, options)
     }
 
-    /// Forward complete parser parameters to the backend, using only the fast path.
+    /// Forward complete parser parameters to the backend, using only the fast
+    /// path.
     #[cfg_attr(not(feature = "compact"), inline(always))]
     fn fast_path_complete<const FORMAT: u128>(bytes: &[u8], options: &Options) -> Result<Self> {
         check_radix!(FORMAT);
         fast_path_complete::<Self, FORMAT>(bytes, options)
     }
 
-    /// Forward partial parser parameters to the backend, using only the fast path.
+    /// Forward partial parser parameters to the backend, using only the fast
+    /// path.
     #[cfg_attr(not(feature = "compact"), inline(always))]
     fn fast_path_partial<const FORMAT: u128>(
         bytes: &[u8],
@@ -515,7 +518,8 @@ pub fn parse_partial_number<'a, const FORMAT: u128>(
     //      We've tried:
     //          - checking for explicit overflow, via `overflowing_mul`.
     //          - counting the max number of steps.
-    //          - subslicing the string, and only processing the first `step` digits.
+    //          - subslicing the string, and only processing the first `step`
+    //            digits.
     //          - pre-computing the maximum power, and only adding until then.
     //
     //      All of these lead to substantial performance penalty.

--- a/lexical-parse-float/src/parse.rs
+++ b/lexical-parse-float/src/parse.rs
@@ -304,8 +304,6 @@ pub fn parse_complete<F: LemireFloat, const FORMAT: u128>(
     }
 
     // Parse our a small representation of our number.
-    // TODO: See if we can do faster number parsing here for small numbers
-    //      Should be able to get fairly fast results
     let num = parse_number!(FORMAT, byte, is_negative, options, parse_number, parse_special);
     // Try the fast-path algorithm.
     if let Some(value) = num.try_fast_path::<_, FORMAT>() {
@@ -504,7 +502,7 @@ pub fn slow_path<F: LemireFloat, const FORMAT: u128>(
 /// This creates a representation of the float as the
 /// significant digits and the decimal exponent.
 #[cfg_attr(not(feature = "compact"), inline(always))]
-#[allow(clippy::collapsible_if)]
+#[allow(clippy::collapsible_if, unused_mut)]
 pub fn parse_partial_number<'a, const FORMAT: u128>(
     mut byte: Bytes<'a, FORMAT>,
     is_negative: bool,
@@ -550,25 +548,29 @@ pub fn parse_partial_number<'a, const FORMAT: u128>(
 
     // Check to see if we have a valid base prefix.
     // NOTE: `read_if` compiles poorly so use `peek` and then `step_unchecked`.
-    let base_prefix = format.base_prefix();
+    #[allow(unused_variables)]
     let mut is_prefix = false;
-    let mut iter = byte.integer_iter();
-    if cfg!(feature = "format") && base_prefix != 0 && iter.peek() == Some(&b'0') {
-        // SAFETY: safe since `byte.len() >= 1`.
-        unsafe { iter.step_unchecked() };
-        // Check to see if the next character is the base prefix.
-        // We must have a format like `0x`, `0d`, `0o`. Note:
-        if let Some(&c) = iter.peek() {
-            is_prefix = if format.case_sensitive_base_prefix() {
-                c == base_prefix
-            } else {
-                c.to_ascii_lowercase() == base_prefix.to_ascii_lowercase()
-            };
-            if is_prefix {
-                // SAFETY: safe since `byte.len() >= 1`.
-                unsafe { iter.step_unchecked() };
-                if iter.is_done() {
-                    return Err(Error::Empty(iter.cursor()));
+    #[cfg(feature = "format")]
+    {
+        let base_prefix = format.base_prefix();
+        let mut iter = byte.integer_iter();
+        if base_prefix != 0 && iter.peek() == Some(&b'0') {
+            // SAFETY: safe since `byte.len() >= 1`.
+            unsafe { iter.step_unchecked() };
+            // Check to see if the next character is the base prefix.
+            // We must have a format like `0x`, `0d`, `0o`. Note:
+            if let Some(&c) = iter.peek() {
+                is_prefix = if format.case_sensitive_base_prefix() {
+                    c == base_prefix
+                } else {
+                    c.to_ascii_lowercase() == base_prefix.to_ascii_lowercase()
+                };
+                if is_prefix {
+                    // SAFETY: safe since `byte.len() >= 1`.
+                    unsafe { iter.step_unchecked() };
+                    if iter.is_done() {
+                        return Err(Error::Empty(iter.cursor()));
+                    }
                 }
             }
         }
@@ -583,7 +585,8 @@ pub fn parse_partial_number<'a, const FORMAT: u128>(
         mantissa = mantissa.wrapping_mul(format.radix() as _).wrapping_add(digit as _);
     });
     let mut n_digits = byte.current_count() - start.current_count();
-    if cfg!(feature = "format") && format.required_integer_digits() && n_digits == 0 {
+    #[cfg(feature = "format")]
+    if format.required_integer_digits() && n_digits == 0 {
         return Err(Error::EmptyInteger(byte.cursor()));
     }
 
@@ -601,7 +604,8 @@ pub fn parse_partial_number<'a, const FORMAT: u128>(
     let integer_digits = unsafe { start.as_slice().get_unchecked(..n_digits) };
 
     // Check if integer leading zeros are disabled.
-    if cfg!(feature = "format") && !is_prefix && format.no_float_leading_zeros() {
+    #[cfg(feature = "format")]
+    if !is_prefix && format.no_float_leading_zeros() {
         if integer_digits.len() > 1 && integer_digits.first() == Some(&b'0') {
             return Err(Error::InvalidLeadingZeros(start.cursor()));
         }
@@ -639,7 +643,8 @@ pub fn parse_partial_number<'a, const FORMAT: u128>(
             debug_assert!(bits_per_digit % bits_per_base == 0);
             exponent = implicit_exponent * bits_per_digit / bits_per_base;
         };
-        if cfg!(feature = "format") && format.required_fraction_digits() && n_after_dot == 0 {
+        #[cfg(feature = "format")]
+        if format.required_fraction_digits() && n_after_dot == 0 {
             return Err(Error::EmptyFraction(byte.cursor()));
         }
     }
@@ -660,7 +665,8 @@ pub fn parse_partial_number<'a, const FORMAT: u128>(
     };
     if is_exponent {
         // Check float format syntax checks.
-        if cfg!(feature = "format") {
+        #[cfg(feature = "format")]
+        {
             if format.no_exponent_notation() {
                 return Err(Error::InvalidExponent(byte.cursor()));
             }
@@ -698,9 +704,11 @@ pub fn parse_partial_number<'a, const FORMAT: u128>(
     // Check to see if we have a valid base suffix.
     // We've already trimmed any leading digit separators here, so we can be safe
     // that the first character **is not** a digit separator.
+    #[allow(unused_variables)]
     let base_suffix = format.base_suffix();
-    if cfg!(feature = "format") && base_suffix != 0 {
-        let is_suffix: bool = if cfg!(feature = "format") && format.case_sensitive_base_suffix() {
+    #[cfg(feature = "format")]
+    if base_suffix != 0 {
+        let is_suffix: bool = if format.case_sensitive_base_suffix() {
             byte.first_is(base_suffix)
         } else {
             byte.case_insensitive_first_is(base_suffix)
@@ -717,7 +725,8 @@ pub fn parse_partial_number<'a, const FORMAT: u128>(
     let end = byte.cursor();
     let mut step = u64_step(format.radix());
     let mut many_digits = false;
-    if cfg!(feature = "format") && !format.required_mantissa_digits() && n_digits == 0 {
+    #[cfg(feature = "format")]
+    if !format.required_mantissa_digits() && n_digits == 0 {
         exponent = 0;
     }
     if n_digits <= step {

--- a/lexical-parse-float/src/shared.rs
+++ b/lexical-parse-float/src/shared.rs
@@ -2,11 +2,12 @@
 
 #![doc(hidden)]
 
-use crate::float::{ExtendedFloat80, RawFloat};
-use crate::mask::{lower_n_halfway, lower_n_mask};
 #[cfg(feature = "power-of-two")]
 use lexical_util::format::NumberFormat;
 use lexical_util::num::AsPrimitive;
+
+use crate::float::{ExtendedFloat80, RawFloat};
+use crate::mask::{lower_n_halfway, lower_n_mask};
 
 // 8 DIGIT
 // -------

--- a/lexical-parse-float/src/slow.rs
+++ b/lexical-parse-float/src/slow.rs
@@ -763,40 +763,54 @@ pub fn bh<F: RawFloat>(float: F) -> ExtendedFloat80 {
     }
 }
 
+// NOTE: There will never be binary factors here.
+
 /// Calculate the integral ceiling of the binary factor from a basen number.
 #[inline(always)]
+#[cfg(feature = "radix")]
 pub const fn integral_binary_factor(radix: u32) -> u32 {
     match radix {
-        3 if cfg!(feature = "radix") => 2,
-        5 if cfg!(feature = "radix") => 3,
-        6 if cfg!(feature = "radix") => 3,
-        7 if cfg!(feature = "radix") => 3,
-        9 if cfg!(feature = "radix") => 4,
+        3 => 2,
+        5 => 3,
+        6 => 3,
+        7 => 3,
+        9 => 4,
         10 => 4,
-        11 if cfg!(feature = "radix") => 4,
-        12 if cfg!(feature = "radix") => 4,
-        13 if cfg!(feature = "radix") => 4,
-        14 if cfg!(feature = "radix") => 4,
-        15 if cfg!(feature = "radix") => 4,
-        17 if cfg!(feature = "radix") => 5,
-        18 if cfg!(feature = "radix") => 5,
-        19 if cfg!(feature = "radix") => 5,
-        20 if cfg!(feature = "radix") => 5,
-        21 if cfg!(feature = "radix") => 5,
-        22 if cfg!(feature = "radix") => 5,
-        23 if cfg!(feature = "radix") => 5,
-        24 if cfg!(feature = "radix") => 5,
-        25 if cfg!(feature = "radix") => 5,
-        26 if cfg!(feature = "radix") => 5,
-        27 if cfg!(feature = "radix") => 5,
-        28 if cfg!(feature = "radix") => 5,
-        29 if cfg!(feature = "radix") => 5,
-        30 if cfg!(feature = "radix") => 5,
-        31 if cfg!(feature = "radix") => 5,
-        33 if cfg!(feature = "radix") => 6,
-        34 if cfg!(feature = "radix") => 6,
-        35 if cfg!(feature = "radix") => 6,
-        36 if cfg!(feature = "radix") => 6,
+        11 => 4,
+        12 => 4,
+        13 => 4,
+        14 => 4,
+        15 => 4,
+        17 => 5,
+        18 => 5,
+        19 => 5,
+        20 => 5,
+        21 => 5,
+        22 => 5,
+        23 => 5,
+        24 => 5,
+        25 => 5,
+        26 => 5,
+        27 => 5,
+        28 => 5,
+        29 => 5,
+        30 => 5,
+        31 => 5,
+        33 => 6,
+        34 => 6,
+        35 => 6,
+        36 => 6,
+        // Invalid radix
+        _ => 0,
+    }
+}
+
+/// Calculate the integral ceiling of the binary factor from a basen number.
+#[inline(always)]
+#[cfg(not(feature = "radix"))]
+pub const fn integral_binary_factor(radix: u32) -> u32 {
+    match radix {
+        10 => 4,
         // Invalid radix
         _ => 0,
     }

--- a/lexical-parse-float/src/slow.rs
+++ b/lexical-parse-float/src/slow.rs
@@ -6,14 +6,8 @@
 
 #![doc(hidden)]
 
-#[cfg(feature = "radix")]
-use crate::bigint::Bigfloat;
-use crate::bigint::{Bigint, Limb, LIMB_BITS};
-use crate::float::{extended_to_float, ExtendedFloat80, RawFloat};
-use crate::limits::{u32_power_limit, u64_power_limit};
-use crate::number::Number;
-use crate::shared;
 use core::cmp;
+
 #[cfg(not(feature = "compact"))]
 use lexical_parse_integer::algorithm;
 use lexical_util::buffer::Buffer;
@@ -23,6 +17,14 @@ use lexical_util::digit::digit_to_char_const;
 use lexical_util::format::NumberFormat;
 use lexical_util::iterator::{AsBytes, BytesIter};
 use lexical_util::num::{AsPrimitive, Integer};
+
+#[cfg(feature = "radix")]
+use crate::bigint::Bigfloat;
+use crate::bigint::{Bigint, Limb, LIMB_BITS};
+use crate::float::{extended_to_float, ExtendedFloat80, RawFloat};
+use crate::limits::{u32_power_limit, u64_power_limit};
+use crate::number::Number;
+use crate::shared;
 
 // ALGORITHM
 // ---------
@@ -111,7 +113,8 @@ pub fn digit_comp<F: RawFloat, const FORMAT: u128>(
     }
 }
 
-/// Generate the significant digits with a positive exponent relative to mantissa.
+/// Generate the significant digits with a positive exponent relative to
+/// mantissa.
 pub fn positive_digit_comp<F: RawFloat, const FORMAT: u128>(
     mut bigmant: Bigint,
     exponent: i32,
@@ -143,7 +146,8 @@ pub fn positive_digit_comp<F: RawFloat, const FORMAT: u128>(
     fp
 }
 
-/// Generate the significant digits with a negative exponent relative to mantissa.
+/// Generate the significant digits with a negative exponent relative to
+/// mantissa.
 ///
 /// This algorithm is quite simple: we have the significant digits `m1 * b^N1`,
 /// where `m1` is the bigint mantissa, `b` is the radix, and `N1` is the radix
@@ -249,7 +253,8 @@ pub fn negative_digit_comp<F: RawFloat, const FORMAT: u128>(
 /// - `count` - The total number of parsed digits
 /// - `counter` - The number of parsed digits since creating the current u32
 /// - `step` - The maximum number of digits for the radix that can fit in a u32.
-/// - `max_digits` - The maximum number of digits that can affect floating-point rounding.
+/// - `max_digits` - The maximum number of digits that can affect floating-point
+///   rounding.
 #[cfg(not(feature = "compact"))]
 macro_rules! try_parse_8digits {
     (
@@ -485,7 +490,8 @@ pub fn parse_mantissa<const FORMAT: u128>(num: Number, max_digits: usize) -> (Bi
 ///
 /// - `iter` - An iterator over all bytes in the buffer
 /// - `num` - The actual digits of the real floating point number.
-/// - `den` - The theoretical digits created by `b+h` to determine if `b` or `b+1`
+/// - `den` - The theoretical digits created by `b+h` to determine if `b` or
+///   `b+1`
 #[cfg(feature = "radix")]
 macro_rules! integer_compare {
     ($iter:ident, $num:ident, $den:ident, $radix:ident) => {{
@@ -522,7 +528,8 @@ macro_rules! integer_compare {
 ///
 /// - `iter` - An iterator over all bytes in the buffer
 /// - `num` - The actual digits of the real floating point number.
-/// - `den` - The theoretical digits created by `b+h` to determine if `b` or `b+1`
+/// - `den` - The theoretical digits created by `b+h` to determine if `b` or
+///   `b+1`
 #[cfg(feature = "radix")]
 macro_rules! fraction_compare {
     ($iter:ident, $num:ident, $den:ident, $radix:ident) => {{
@@ -660,9 +667,11 @@ pub fn byte_comp<F: RawFloat, const FORMAT: u128>(
 
 /// Compare digits between the generated values the ratio and the actual view.
 ///
-/// - `number` - The representation of the float as a big number, with the parsed digits.
+/// - `number` - The representation of the float as a big number, with the
+///   parsed digits.
 /// - `num` - The actual digits of the real floating point number.
-/// - `den` - The theoretical digits created by `b+h` to determine if `b` or `b+1`
+/// - `den` - The theoretical digits created by `b+h` to determine if `b` or
+///   `b+1`
 #[cfg(feature = "radix")]
 pub fn compare_bytes<const FORMAT: u128>(
     number: Number,

--- a/lexical-parse-float/src/table_binary.rs
+++ b/lexical-parse-float/src/table_binary.rs
@@ -4,9 +4,10 @@
 #![cfg(not(feature = "compact"))]
 #![doc(hidden)]
 
+use lexical_util::num::Float;
+
 #[cfg(not(feature = "radix"))]
 use crate::table_decimal::*;
-use lexical_util::num::Float;
 
 // HELPERS
 // -------

--- a/lexical-parse-float/src/table_decimal.rs
+++ b/lexical-parse-float/src/table_decimal.rs
@@ -3,10 +3,11 @@
 #![doc(hidden)]
 #![cfg(not(feature = "compact"))]
 
+use static_assertions::const_assert;
+
 #[cfg(not(feature = "radix"))]
 use crate::bigint::Limb;
 use crate::limits::{f32_exponent_limit, f64_exponent_limit, f64_mantissa_limit, u64_power_limit};
-use static_assertions::const_assert;
 
 // HELPERS
 // -------

--- a/lexical-parse-float/src/table_radix.rs
+++ b/lexical-parse-float/src/table_radix.rs
@@ -5,12 +5,13 @@
 #![doc(hidden)]
 #![allow(clippy::excessive_precision)]
 
+use lexical_util::assert::debug_assert_radix;
+use static_assertions::const_assert;
+
 use crate::bigint::Limb;
 use crate::limits::{f32_exponent_limit, f64_exponent_limit, f64_mantissa_limit, u64_power_limit};
 use crate::table_binary::*;
 use crate::table_decimal::*;
-use lexical_util::assert::debug_assert_radix;
-use static_assertions::const_assert;
 
 // HELPERS
 // -------

--- a/lexical-parse-float/tests/api_tests.rs
+++ b/lexical-parse-float/tests/api_tests.rs
@@ -1,8 +1,8 @@
 mod util;
 
-use crate::util::default_proptest_config;
 #[cfg(feature = "format")]
 use core::num;
+
 use lexical_parse_float::{FromLexical, FromLexicalWithOptions, Options};
 #[cfg(feature = "f16")]
 use lexical_util::bf16::bf16;
@@ -16,6 +16,8 @@ use lexical_util::format::NumberFormatBuilder;
 use lexical_util::format::STANDARD;
 use lexical_util::num::Float;
 use proptest::prelude::*;
+
+use crate::util::default_proptest_config;
 
 #[test]
 fn special_bytes_test() {

--- a/lexical-parse-float/tests/libm_tests.rs
+++ b/lexical-parse-float/tests/libm_tests.rs
@@ -5,6 +5,7 @@
 // and is similarly licensed under an Apache2.0/MIT license
 
 use core::f64;
+
 use lexical_parse_float::libm;
 
 #[test]
@@ -167,7 +168,8 @@ fn powd_infinity_as_base() {
 #[test]
 fn infinity_as_exponent() {
     // Positive/Negative base greater than 1:
-    // (pos/neg > 1 ^ Infinity should be Infinity - note this excludes NAN as the base)
+    // (pos/neg > 1 ^ Infinity should be Infinity - note this excludes NAN as the
+    // base)
     powd_test_sets_as_base(&ALL[5..(ALL.len() - 2)], f64::INFINITY, f64::INFINITY);
 
     // (pos/neg > 1 ^ -Infinity should be 0.0)
@@ -227,7 +229,8 @@ fn special_cases() {
     powd_test_sets(ALL, &|v: f64| libm::powd(v, -1.0), &|v: f64| 1.0 / v);
 
     // Factoring -1 out:
-    // (negative anything ^ integer should be (-1 ^ integer) * (positive anything ^ integer))
+    // (negative anything ^ integer should be (-1 ^ integer) * (positive anything ^
+    // integer))
     [POS_ZERO, NEG_ZERO, POS_ONE, NEG_ONE, POS_EVENS, NEG_EVENS].iter().for_each(|int_set| {
         int_set.iter().for_each(|int| {
             powd_test_sets(ALL, &|v: f64| libm::powd(-v, *int), &|v: f64| {

--- a/lexical-parse-float/tests/slow_tests.rs
+++ b/lexical-parse-float/tests/slow_tests.rs
@@ -2,6 +2,7 @@ mod stackvec;
 
 #[cfg(feature = "radix")]
 use core::cmp;
+
 #[cfg(feature = "radix")]
 use lexical_parse_float::bigint::Bigfloat;
 use lexical_parse_float::bigint::Bigint;

--- a/lexical-parse-float/tests/stackvec_tests.rs
+++ b/lexical-parse-float/tests/stackvec_tests.rs
@@ -1,6 +1,7 @@
 mod stackvec;
 
 use core::cmp;
+
 use lexical_parse_float::bigint::{self, Limb, StackVec, LIMB_BITS};
 use stackvec::vec_from_u32;
 

--- a/lexical-parse-float/tests/util.rs
+++ b/lexical-parse-float/tests/util.rs
@@ -24,8 +24,8 @@ pub fn default_proptest_config() -> ProptestConfig {
     }
 }
 
-// This is almost identical to quickcheck's itself, just to add default arguments
-//  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
+// This is almost identical to quickcheck's itself, just to add default
+// arguments  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
 // The code is unlicensed.
 #[macro_export]
 macro_rules! default_quickcheck {

--- a/lexical-parse-integer/src/api.rs
+++ b/lexical-parse-integer/src/api.rs
@@ -2,10 +2,11 @@
 
 #![doc(hidden)]
 
-use crate::options::{Options, STANDARD as DEFAULT_OPTIONS};
-use crate::parse::ParseInteger;
 use lexical_util::format::{NumberFormat, STANDARD};
 use lexical_util::{from_lexical, from_lexical_with_options};
+
+use crate::options::{Options, STANDARD as DEFAULT_OPTIONS};
+use crate::parse::ParseInteger;
 
 /// Implement FromLexical for numeric type.
 ///

--- a/lexical-parse-integer/src/lib.rs
+++ b/lexical-parse-integer/src/lib.rs
@@ -68,10 +68,11 @@ pub mod parse;
 mod api;
 
 // Re-exports
-pub use self::api::{FromLexical, FromLexicalWithOptions};
-#[doc(inline)]
-pub use self::options::{Options, OptionsBuilder};
 pub use lexical_util::error::Error;
 pub use lexical_util::format::{self, NumberFormatBuilder};
 pub use lexical_util::options::ParseOptions;
 pub use lexical_util::result::Result;
+
+pub use self::api::{FromLexical, FromLexicalWithOptions};
+#[doc(inline)]
+pub use self::options::{Options, OptionsBuilder};

--- a/lexical-parse-integer/src/parse.rs
+++ b/lexical-parse-integer/src/parse.rs
@@ -3,11 +3,11 @@
 #![doc(hidden)]
 
 // Select the correct back-end.
-use crate::algorithm::{algorithm_complete, algorithm_partial};
-use crate::Options;
-
 use lexical_util::num::Integer;
 use lexical_util::result::Result;
+
+use crate::algorithm::{algorithm_complete, algorithm_partial};
+use crate::Options;
 
 /// Parse integer trait, implemented in terms of the optimized back-end.
 pub trait ParseInteger: Integer {

--- a/lexical-parse-integer/tests/algorithm_tests.rs
+++ b/lexical-parse-integer/tests/algorithm_tests.rs
@@ -2,7 +2,6 @@
 
 mod util;
 
-use crate::util::default_proptest_config;
 use lexical_parse_integer::algorithm;
 use lexical_parse_integer::options::SMALL_NUMBERS;
 use lexical_util::format::STANDARD;
@@ -10,6 +9,8 @@ use lexical_util::iterator::AsBytes;
 use proptest::prelude::*;
 #[cfg(feature = "power-of-two")]
 use util::from_radix;
+
+use crate::util::default_proptest_config;
 
 #[test]
 fn test_is_4digits() {
@@ -143,8 +144,8 @@ fn algorithm_test() {
     assert_eq!(parse_i32(b"+12345"), Ok((12345, 6)));
     assert_eq!(parse_i32(b"+123.45"), Ok((123, 4)));
 
-    // Need to try with other radixes here, especially to ensure no regressions with #71.
-    // Issue: https://github.com/Alexhuszagh/rust-lexical/issues/71
+    // Need to try with other radixes here, especially to ensure no regressions with
+    // #71. Issue: https://github.com/Alexhuszagh/rust-lexical/issues/71
     #[cfg(feature = "power-of-two")]
     {
         // This should try to invoke `parse_4digits` since it's more than

--- a/lexical-parse-integer/tests/api_tests.rs
+++ b/lexical-parse-integer/tests/api_tests.rs
@@ -1,6 +1,5 @@
 mod util;
 
-use crate::util::default_proptest_config;
 use lexical_parse_integer::{FromLexical, FromLexicalWithOptions, Options};
 use lexical_util::error::Error;
 #[cfg(feature = "format")]
@@ -9,6 +8,8 @@ use lexical_util::format::STANDARD;
 use proptest::prelude::*;
 #[cfg(feature = "power-of-two")]
 use util::from_radix;
+
+use crate::util::default_proptest_config;
 
 #[test]
 fn u8_decimal_test() {

--- a/lexical-parse-integer/tests/util.rs
+++ b/lexical-parse-integer/tests/util.rs
@@ -31,8 +31,8 @@ pub fn default_proptest_config() -> ProptestConfig {
     }
 }
 
-// This is almost identical to quickcheck's itself, just to add default arguments
-//  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
+// This is almost identical to quickcheck's itself, just to add default
+// arguments  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
 // The code is unlicensed.
 #[macro_export]
 macro_rules! default_quickcheck {

--- a/lexical-size/bin/parse.rs
+++ b/lexical-size/bin/parse.rs
@@ -4,11 +4,12 @@ macro_rules! integer_module {
         #[cfg(not(feature = "lexical"))]
         mod core_parse;
 
+        use std::io::BufRead;
+
         #[cfg(not(feature = "lexical"))]
         use core_parse::parse_int;
         #[cfg(feature = "lexical")]
         use lexical_parse_integer::FromLexical;
-        use std::io::BufRead;
 
         pub fn main() {
             #[cfg(feature = "lexical")]
@@ -33,9 +34,10 @@ macro_rules! integer_module {
 #[allow(unused_macros)]
 macro_rules! float_module {
     ($t:ty) => {
+        use std::io::BufRead;
+
         #[cfg(feature = "lexical")]
         use lexical_parse_float::FromLexical;
-        use std::io::BufRead;
 
         pub fn main() {
             #[cfg(feature = "lexical")]

--- a/lexical-size/bin/write.rs
+++ b/lexical-size/bin/write.rs
@@ -3,11 +3,12 @@ macro_rules! integer_module {
     ($t:ty) => {
         #[cfg(feature = "lexical")]
         use core::mem;
-        #[cfg(feature = "lexical")]
-        use lexical_write_integer::ToLexical;
         use std::io::BufRead;
         #[cfg(not(feature = "lexical"))]
         use std::io::Write;
+
+        #[cfg(feature = "lexical")]
+        use lexical_write_integer::ToLexical;
 
         pub fn main() {
             let value: $t = unsafe {
@@ -48,11 +49,12 @@ macro_rules! float_module {
     ($t:ty) => {
         #[cfg(feature = "lexical")]
         use core::mem;
-        #[cfg(feature = "lexical")]
-        use lexical_write_float::ToLexical;
         use std::io::BufRead;
         #[cfg(not(feature = "lexical"))]
         use std::io::Write;
+
+        #[cfg(feature = "lexical")]
+        use lexical_write_float::ToLexical;
 
         pub fn main() {
             let value: $t = unsafe {

--- a/lexical-util/src/api.rs
+++ b/lexical-util/src/api.rs
@@ -150,7 +150,8 @@ macro_rules! to_lexical {
 #[cfg(feature = "write")]
 macro_rules! to_lexical_with_options {
     () => {
-        /// Trait for numerical types that can be serialized to bytes with custom options.
+        /// Trait for numerical types that can be serialized to bytes with custom
+        /// options.
         ///
         /// To determine the number of bytes required to serialize a value to
         /// string, check the associated constants from a required trait:

--- a/lexical-util/src/constants.rs
+++ b/lexical-util/src/constants.rs
@@ -22,7 +22,8 @@ pub trait FormattedSize {
     /// [`lexical_write_float`]: https://github.com/Alexhuszagh/rust-lexical/tree/main/lexical-write-float
     const FORMATTED_SIZE: usize;
 
-    /// Maximum number of bytes required to serialize a number to a decimal string.
+    /// Maximum number of bytes required to serialize a number to a decimal
+    /// string.
     ///
     /// Note that this value may be insufficient if digit precision control,
     /// exponent break points, or disabling exponent notation is used. If
@@ -96,7 +97,8 @@ formatted_size_impl! { usize 20 128 ; }
 ///
 /// Note that this value may be insufficient if digit precision control,
 /// exponent break points, or disabling exponent notation is used.
-/// Please read the documentation in [`lexical_write_float`] for more information.
+/// Please read the documentation in [`lexical_write_float`] for more
+/// information.
 ///
 /// [`lexical_write_float`]: https://github.com/Alexhuszagh/rust-lexical/tree/main/lexical-write-float
 pub const BUFFER_SIZE: usize = f64::FORMATTED_SIZE;

--- a/lexical-util/src/digit.rs
+++ b/lexical-util/src/digit.rs
@@ -96,7 +96,8 @@ pub const fn char_is_digit(c: u8, radix: u32) -> bool {
     char_to_digit(c, radix).is_some()
 }
 
-/// Convert a digit to a character. This uses a pre-computed table to avoid branching.
+/// Convert a digit to a character. This uses a pre-computed table to avoid
+/// branching.
 ///
 /// # Panics
 ///

--- a/lexical-util/src/div128.rs
+++ b/lexical-util/src/div128.rs
@@ -156,11 +156,15 @@ pub fn slow_u128_divrem(n: u128, d: u64, d_ctlz: u32) -> (u128, u64) {
 /// For the number of digits processed, see
 /// [min_step](crate::step::min_step).
 #[inline(always)]
+#[allow(clippy::needless_return)]
 pub fn u128_divrem(n: u128, radix: u32) -> (u128, u64) {
     debug_assert_radix(radix);
 
-    if cfg!(feature = "radix") {
-        match radix {
+    // NOTE: to avoid branching when w don't need it, we use the compile logic
+
+    #[cfg(feature = "radix")]
+    {
+        return match radix {
             2 => u128_divrem_2(n),
             3 => u128_divrem_3(n),
             4 => u128_divrem_4(n),
@@ -197,9 +201,12 @@ pub fn u128_divrem(n: u128, radix: u32) -> (u128, u64) {
             35 => u128_divrem_35(n),
             36 => u128_divrem_36(n),
             _ => unreachable!(),
-        }
-    } else if cfg!(feature = "power-of-two") {
-        match radix {
+        };
+    }
+
+    #[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+    {
+        return match radix {
             2 => u128_divrem_2(n),
             4 => u128_divrem_4(n),
             8 => u128_divrem_8(n),
@@ -207,9 +214,12 @@ pub fn u128_divrem(n: u128, radix: u32) -> (u128, u64) {
             16 => u128_divrem_16(n),
             32 => u128_divrem_32(n),
             _ => unreachable!(),
-        }
-    } else {
-        u128_divrem_10(n)
+        };
+    }
+
+    #[cfg(not(feature = "power-of-two"))]
+    {
+        return u128_divrem_10(n);
     }
 }
 
@@ -222,26 +232,31 @@ pub fn u128_divrem(n: u128, radix: u32) -> (u128, u64) {
 // in the function signatures of the functions they call.
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn u128_divrem_2(n: u128) -> (u128, u64) {
     pow2_u128_divrem(n, 18446744073709551615, 64)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_3(n: u128) -> (u128, u64) {
     slow_u128_divrem(n, 12157665459056928801, 0)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn u128_divrem_4(n: u128) -> (u128, u64) {
     pow2_u128_divrem(n, 18446744073709551615, 64)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_5(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 7450580596923828125, 105312291668557186697918027683670432319, 61)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_6(n: u128) -> (u128, u64) {
     fast_u128_divrem(
         n,
@@ -254,16 +269,19 @@ fn u128_divrem_6(n: u128) -> (u128, u64) {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_7(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 3909821048582988049, 200683792729517998822275406364627986707, 61)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn u128_divrem_8(n: u128) -> (u128, u64) {
     pow2_u128_divrem(n, 9223372036854775807, 63)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_9(n: u128) -> (u128, u64) {
     slow_u128_divrem(n, 12157665459056928801, 0)
 }
@@ -281,21 +299,25 @@ fn u128_divrem_10(n: u128) -> (u128, u64) {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_11(n: u128) -> (u128, u64) {
     slow_u128_divrem(n, 5559917313492231481, 1)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_12(n: u128) -> (u128, u64) {
     slow_u128_divrem(n, 2218611106740436992, 3)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_13(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 8650415919381337933, 181410402513790565292660635782582404765, 62)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_14(n: u128) -> (u128, u64) {
     fast_u128_divrem(
         n,
@@ -308,21 +330,25 @@ fn u128_divrem_14(n: u128) -> (u128, u64) {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_15(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 6568408355712890625, 1866504587258795246613513364166764993, 55)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn u128_divrem_16(n: u128) -> (u128, u64) {
     pow2_u128_divrem(n, 18446744073709551615, 64)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_17(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 2862423051509815793, 68529153692836345537218837732158950089, 59)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_18(n: u128) -> (u128, u64) {
     fast_u128_divrem(
         n,
@@ -335,11 +361,13 @@ fn u128_divrem_18(n: u128) -> (u128, u64) {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_19(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 15181127029874798299, 25842538415601616733690423925257626679, 60)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_20(n: u128) -> (u128, u64) {
     fast_u128_divrem(
         n,
@@ -352,21 +380,25 @@ fn u128_divrem_20(n: u128) -> (u128, u64) {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_21(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 3243919932521508681, 120939747781233590383781714337497669585, 60)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_22(n: u128) -> (u128, u64) {
     slow_u128_divrem(n, 6221821273427820544, 1)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_23(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 11592836324538749809, 270731922700393644432243678371210997949, 63)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_24(n: u128) -> (u128, u64) {
     fast_u128_divrem(
         n,
@@ -379,11 +411,13 @@ fn u128_divrem_24(n: u128) -> (u128, u64) {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_25(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 1490116119384765625, 131640364585696483372397534604588040399, 59)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_26(n: u128) -> (u128, u64) {
     fast_u128_divrem(
         n,
@@ -396,11 +430,13 @@ fn u128_divrem_26(n: u128) -> (u128, u64) {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_27(n: u128) -> (u128, u64) {
     slow_u128_divrem(n, 4052555153018976267, 2)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_28(n: u128) -> (u128, u64) {
     fast_u128_divrem(
         n,
@@ -413,31 +449,37 @@ fn u128_divrem_28(n: u128) -> (u128, u64) {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_29(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 10260628712958602189, 152941450056053853841698190746050519297, 62)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_30(n: u128) -> (u128, u64) {
     slow_u128_divrem(n, 15943230000000000000, 0)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_31(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 787662783788549761, 124519929891402176328714857711808162537, 58)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn u128_divrem_32(n: u128) -> (u128, u64) {
     pow2_u128_divrem(n, 1152921504606846975, 60)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_33(n: u128) -> (u128, u64) {
     slow_u128_divrem(n, 1667889514952984961, 3)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_34(n: u128) -> (u128, u64) {
     fast_u128_divrem(
         n,
@@ -450,11 +492,13 @@ fn u128_divrem_34(n: u128) -> (u128, u64) {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_35(n: u128) -> (u128, u64) {
     moderate_u128_divrem(n, 3379220508056640625, 116097442450503652080238494022501325491, 60)
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 fn u128_divrem_36(n: u128) -> (u128, u64) {
     fast_u128_divrem(
         n,

--- a/lexical-util/src/div128.rs
+++ b/lexical-util/src/div128.rs
@@ -3,10 +3,10 @@
 //! # Fast Algorithms
 //!
 //! The more optimized algorithms for calculating the divisor constants are
-//! based off of the paper "Division by Invariant Integers Using Multiplication",
-//! by T. Granlund and P. Montgomery, in "Proc. of the SIGPLAN94 Conference
-//! on Programming Language Design and Implementation", available online
-//! [here](https://gmplib.org/~tege/divcnst-pldi94.pdf).
+//! based off of the paper "Division by Invariant Integers Using
+//! Multiplication", by T. Granlund and P. Montgomery, in "Proc. of the
+//! SIGPLAN94 Conference on Programming Language Design and Implementation",
+//! available online [here](https://gmplib.org/~tege/divcnst-pldi94.pdf).
 //!
 //! This approach is derived from the Rust algorithm for formatting 128-bit
 //! values, and therefore is similarly dual-licensed under MIT/Apache-2.0.
@@ -59,7 +59,8 @@ pub const fn pow2_u128_divrem(n: u128, mask: u64, shr: u32) -> (u128, u64) {
     (quot, rem)
 }
 
-/// Fast division/remainder algorithm for u128, without a fast native approximation.
+/// Fast division/remainder algorithm for u128, without a fast native
+/// approximation.
 #[inline(always)]
 #[allow(clippy::many_single_char_names)]
 pub fn fast_u128_divrem(
@@ -79,7 +80,8 @@ pub fn fast_u128_divrem(
     (quot, rem)
 }
 
-/// Fast division/remainder algorithm for u128, without a fast native approximation.
+/// Fast division/remainder algorithm for u128, without a fast native
+/// approximation.
 #[inline(always)]
 #[allow(clippy::many_single_char_names)]
 pub fn moderate_u128_divrem(n: u128, d: u64, factor: u128, factor_shr: u32) -> (u128, u64) {
@@ -117,8 +119,8 @@ pub fn slow_u128_divrem(n: u128, d: u64, d_ctlz: u32) -> (u128, u64) {
     let mut r: u128 = n >> sr;
     let mut carry: u64 = 0;
 
-    // Don't use a range because they may generate references to memcpy in unoptimized code
-    // Loop invariants:  r < d; carry is 0 or 1
+    // Don't use a range because they may generate references to memcpy in
+    // unoptimized code Loop invariants:  r < d; carry is 0 or 1
     let mut i = 0;
     while i < sr {
         i += 1;

--- a/lexical-util/src/error.rs
+++ b/lexical-util/src/error.rs
@@ -4,9 +4,10 @@
 //! bindings.
 
 use core::{fmt, mem};
-use static_assertions::const_assert;
 #[cfg(feature = "std")]
 use std::error;
+
+use static_assertions::const_assert;
 
 /// Error code during parsing, indicating failure type.
 #[non_exhaustive]

--- a/lexical-util/src/f16.rs
+++ b/lexical-util/src/f16.rs
@@ -14,9 +14,10 @@
 #![cfg(feature = "f16")]
 #![doc(hidden)]
 
-use crate::num::Float;
 use core::cmp::Ordering;
 use core::{fmt, ops};
+
+use crate::num::Float;
 
 /// Half-precision IEEE-754 floating point type.
 #[allow(non_camel_case_types)]
@@ -179,8 +180,8 @@ impl ops::RemAssign for f16 {
 //     (mantissa & round_bit) != 0 && (mantissa & (2 * round_bit)) != 0
 // (If removed part == tie and retained part is even, do not round up.)
 // These two conditions can be combined into one:
-//     (mantissa & round_bit) != 0 && (mantissa & ((round_bit - 1) | (2 * round_bit))) != 0
-// which can be simplified into
+//     (mantissa & round_bit) != 0 && (mantissa & ((round_bit - 1) | (2 *
+// round_bit))) != 0 which can be simplified into
 //     (mantissa & round_bit) != 0 && (mantissa & (3 * round_bit - 1)) != 0
 
 fn f16_to_f32(half: f16) -> f32 {

--- a/lexical-util/src/feature_format.rs
+++ b/lexical-util/src/feature_format.rs
@@ -67,7 +67,8 @@
 //      double parse(const char* string) {
 //          char* end;
 //          double result = strtod(string, &end);
-//          if (std::distance(string, reinterpret_cast<const char*>(end)) != strlen(string)) {
+//          auto endp = reinterpret_cast<const char*>(end);
+//          if (std::distance(string, endp) != strlen(string)) {
 //              throw std::invalid_argument("did not consume entire string.");
 //          }
 //          return result;
@@ -507,7 +508,8 @@
 // -----------
 //
 // Setup:
-//      Save to `main.m` and run `gcc -o main -lobjc -lgnustep-base main.m -fconstant-string-class=NSConstantString`.
+//      Save to `main.m` and run `gcc -o main -lobjc -lgnustep-base main.m
+// -fconstant-string-class=NSConstantString`.
 //
 // Code:
 //      ```text
@@ -693,12 +695,13 @@
 //      db.movie.find()
 //      ```
 
-use crate::error::Error;
-use crate::format_builder::NumberFormatBuilder;
-use crate::format_flags as flags;
 use core::num;
 
 use static_assertions::const_assert;
+
+use crate::error::Error;
+use crate::format_builder::NumberFormatBuilder;
+use crate::format_flags as flags;
 
 /// Add multiple flags to SyntaxFormat.
 macro_rules! from_flag {

--- a/lexical-util/src/format.rs
+++ b/lexical-util/src/format.rs
@@ -245,15 +245,15 @@
 //! - [is_valid_punctuation]
 //! - [is_valid_radix]
 
+use static_assertions::const_assert;
+
+use crate::error::Error;
 #[cfg(feature = "format")]
 pub use crate::feature_format::*;
 pub use crate::format_builder::*;
 pub use crate::format_flags::*;
 #[cfg(not(feature = "format"))]
 pub use crate::not_feature_format::*;
-
-use crate::error::Error;
-use static_assertions::const_assert;
 
 /// Determine if the format packed struct is valid.
 #[inline(always)]

--- a/lexical-util/src/format_builder.rs
+++ b/lexical-util/src/format_builder.rs
@@ -1,8 +1,10 @@
 //! Builder for the number format.
 
-use crate::format_flags as flags;
 use core::{mem, num};
+
 use static_assertions::const_assert;
+
+use crate::format_flags as flags;
 
 /// Type with the exact same size as a `u8`.
 pub type OptionU8 = Option<num::NonZeroU8>;
@@ -53,38 +55,70 @@ const fn unwrap_or_zero(option: OptionU8) -> u8 {
 /// * `mantissa_radix`                          - Radix for mantissa digits.
 /// * `exponent_base`                           - Base for the exponent.
 /// * `exponent_radix`                          - Radix for the exponent digits.
-/// * `base_prefix`                             - Optional character for the base prefix.
-/// * `base_suffix`                             - Optional character for the base suffix.
-/// * `required_integer_digits`                 - If digits are required before the decimal point.
-/// * `required_fraction_digits`                - If digits are required after the decimal point.
-/// * `required_exponent_digits`                - If digits are required after the exponent character.
-/// * `required_mantissa_digits`                - If at least 1 significant digit is required.
-/// * `no_positive_mantissa_sign`               - If positive sign before the mantissa is not allowed.
-/// * `required_mantissa_sign`                  - If positive sign before the mantissa is required.
-/// * `no_exponent_notation`                    - If exponent notation is not allowed.
-/// * `no_positive_exponent_sign`               - If positive sign before the exponent is not allowed.
-/// * `required_exponent_sign`                  - If sign before the exponent is required.
-/// * `no_exponent_without_fraction`            - If exponent without fraction is not allowed.
-/// * `no_special`                              - If special (non-finite) values are not allowed.
-/// * `case_sensitive_special`                  - If special (non-finite) values are case-sensitive.
-/// * `no_integer_leading_zeros`                - If leading zeros before an integer are not allowed.
-/// * `no_float_leading_zeros`                  - If leading zeros before a float are not allowed.
-/// * `required_exponent_notation`              - If exponent notation is required.
-/// * `case_sensitive_exponent`                 - If exponent characters are case-sensitive.
-/// * `case_sensitive_base_prefix`              - If base prefixes are case-sensitive.
-/// * `case_sensitive_base_suffix`              - If base suffixes are case-sensitive.
-/// * `integer_internal_digit_separator`        - If digit separators are allowed between integer digits.
-/// * `fraction_internal_digit_separator`       - If digit separators are allowed between fraction digits.
-/// * `exponent_internal_digit_separator`       - If digit separators are allowed between exponent digits.
-/// * `integer_leading_digit_separator`         - If a digit separator is allowed before any integer digits.
-/// * `fraction_leading_digit_separator`        - If a digit separator is allowed before any fraction digits.
-/// * `exponent_leading_digit_separator`        - If a digit separator is allowed before any exponent digits.
-/// * `integer_trailing_digit_separator`        - If a digit separator is allowed after any integer digits.
-/// * `fraction_trailing_digit_separator`       - If a digit separator is allowed after any fraction digits.
-/// * `exponent_trailing_digit_separator`       - If a digit separator is allowed after any exponent digits.
-/// * `integer_consecutive_digit_separator`     - If multiple consecutive integer digit separators are allowed.
-/// * `fraction_consecutive_digit_separator`    - If multiple consecutive fraction digit separators are allowed.
-/// * `special_digit_separator`                 - If any digit separators are allowed in special (non-finite) values.
+/// * `base_prefix`                             - Optional character for the
+///   base prefix.
+/// * `base_suffix`                             - Optional character for the
+///   base suffix.
+/// * `required_integer_digits`                 - If digits are required before
+///   the decimal point.
+/// * `required_fraction_digits`                - If digits are required after
+///   the decimal point.
+/// * `required_exponent_digits`                - If digits are required after
+///   the exponent character.
+/// * `required_mantissa_digits`                - If at least 1 significant
+///   digit is required.
+/// * `no_positive_mantissa_sign`               - If positive sign before the
+///   mantissa is not allowed.
+/// * `required_mantissa_sign`                  - If positive sign before the
+///   mantissa is required.
+/// * `no_exponent_notation`                    - If exponent notation is not
+///   allowed.
+/// * `no_positive_exponent_sign`               - If positive sign before the
+///   exponent is not allowed.
+/// * `required_exponent_sign`                  - If sign before the exponent is
+///   required.
+/// * `no_exponent_without_fraction`            - If exponent without fraction
+///   is not allowed.
+/// * `no_special`                              - If special (non-finite) values
+///   are not allowed.
+/// * `case_sensitive_special`                  - If special (non-finite) values
+///   are case-sensitive.
+/// * `no_integer_leading_zeros`                - If leading zeros before an
+///   integer are not allowed.
+/// * `no_float_leading_zeros`                  - If leading zeros before a
+///   float are not allowed.
+/// * `required_exponent_notation`              - If exponent notation is
+///   required.
+/// * `case_sensitive_exponent`                 - If exponent characters are
+///   case-sensitive.
+/// * `case_sensitive_base_prefix`              - If base prefixes are
+///   case-sensitive.
+/// * `case_sensitive_base_suffix`              - If base suffixes are
+///   case-sensitive.
+/// * `integer_internal_digit_separator`        - If digit separators are
+///   allowed between integer digits.
+/// * `fraction_internal_digit_separator`       - If digit separators are
+///   allowed between fraction digits.
+/// * `exponent_internal_digit_separator`       - If digit separators are
+///   allowed between exponent digits.
+/// * `integer_leading_digit_separator`         - If a digit separator is
+///   allowed before any integer digits.
+/// * `fraction_leading_digit_separator`        - If a digit separator is
+///   allowed before any fraction digits.
+/// * `exponent_leading_digit_separator`        - If a digit separator is
+///   allowed before any exponent digits.
+/// * `integer_trailing_digit_separator`        - If a digit separator is
+///   allowed after any integer digits.
+/// * `fraction_trailing_digit_separator`       - If a digit separator is
+///   allowed after any fraction digits.
+/// * `exponent_trailing_digit_separator`       - If a digit separator is
+///   allowed after any exponent digits.
+/// * `integer_consecutive_digit_separator`     - If multiple consecutive
+///   integer digit separators are allowed.
+/// * `fraction_consecutive_digit_separator`    - If multiple consecutive
+///   fraction digit separators are allowed.
+/// * `special_digit_separator`                 - If any digit separators are
+///   allowed in special (non-finite) values.
 ///
 /// # Write Integer Fields
 ///

--- a/lexical-util/src/format_flags.rs
+++ b/lexical-util/src/format_flags.rs
@@ -661,6 +661,9 @@ pub const fn radix_from_flags(format: u128, mask: u128, shift: i32) -> u32 {
 // VALIDATORS
 // ----------
 
+// NOTE: All of these are only used when building formats so it doesn't matter if
+// they have performance issues, since these will be built at compile time.
+
 /// Determine if the provided exponent flags are valid.
 #[inline(always)]
 pub const fn is_valid_exponent_flags(format: u128) -> bool {

--- a/lexical-util/src/iterator.rs
+++ b/lexical-util/src/iterator.rs
@@ -6,11 +6,9 @@
 #![cfg(feature = "parse")]
 
 pub use crate::buffer::Buffer;
-
 // Re-export our digit iterators.
 #[cfg(not(feature = "format"))]
 pub use crate::noskip::{AsBytes, Bytes};
-
 #[cfg(feature = "format")]
 pub use crate::skip::{AsBytes, Bytes};
 
@@ -58,7 +56,8 @@ pub unsafe trait BytesIter<'a>: Iterator<Item = &'a u8> + Buffer<'a> {
         unsafe { self.set_cursor(0) };
     }
 
-    /// Get a slice to the full buffer, which may or may not be the same as `as_slice`.
+    /// Get a slice to the full buffer, which may or may not be the same as
+    /// `as_slice`.
     fn as_full_slice(&self) -> &'a [u8];
 
     /// Get the current number of values returned by the iterator.
@@ -154,7 +153,8 @@ pub unsafe trait BytesIter<'a>: Iterator<Item = &'a u8> + Buffer<'a> {
         }
     }
 
-    /// Peek the next value and consume it if the read value matches the expected one.
+    /// Peek the next value and consume it if the read value matches the
+    /// expected one.
     #[inline(always)]
     fn read_if<Pred: FnOnce(&u8) -> bool>(&mut self, pred: Pred) -> Option<Self::Item> {
         if let Some(peeked) = self.peek() {

--- a/lexical-util/src/lib.rs
+++ b/lexical-util/src/lib.rs
@@ -47,22 +47,26 @@
 //! bytes internally. To guarantee safety, for non-skip iterators you
 //! must implement [BytesIter::is_consumed][is_consumed] correctly.
 //!
-//! This must correctly determine if there are any elements left in the iterator.
-//! If the buffer is contiguous, this can just be `index == self.len()`, but for
-//! a non-contiguous iterator it must skip any digits to advance to the element
-//! next to be returned or the iterator itself will be unsafe. **ALL** other
-//! safety invariants depend on this being implemented correctly.
+//! This must correctly determine if there are any elements left in the
+//! iterator. If the buffer is contiguous, this can just be `index ==
+//! self.len()`, but for a non-contiguous iterator it must skip any digits to
+//! advance to the element next to be returned or the iterator itself will be
+//! unsafe. **ALL** other safety invariants depend on this being implemented
+//! correctly.
 //!
-//! To see if the cursor is at the end of the buffer, use [BytesIter::is_done][is_done].
+//! To see if the cursor is at the end of the buffer, use
+//! [BytesIter::is_done][is_done].
 //!
 //! Any iterators must be peekable: you must be able to read and return the next
-//! value without advancing the iterator past that point. For iterators that skip
-//! bytes, this means advancing to the next element to be returned and returning
-//! that value. Therefore, [peek_unchecked] for skip iterators must be implemented
-//! in terms of [peek]: you must peek the next element and [peek_unchecked] will
-//! merely unwrap this value. Contiguous iterators can use raw indexing instead.
+//! value without advancing the iterator past that point. For iterators that
+//! skip bytes, this means advancing to the next element to be returned and
+//! returning that value. Therefore, [peek_unchecked] for skip iterators must be
+//! implemented in terms of [peek]: you must peek the next element and
+//! [peek_unchecked] will merely unwrap this value. Contiguous iterators can use
+//! raw indexing instead.
 //!
-//! For examples of how to safely implement skip iterators, you can do something like:
+//! For examples of how to safely implement skip iterators, you can do something
+//! like:
 //!
 //! ```rust,ignore
 //! unsafe impl<_> BytesIter<_> for MyIter {

--- a/lexical-util/src/noskip.rs
+++ b/lexical-util/src/noskip.rs
@@ -5,8 +5,9 @@
 
 #![cfg(all(feature = "parse", not(feature = "format")))]
 
-use crate::{buffer::Buffer, iterator::BytesIter};
 use core::{mem, ptr};
+
+use crate::{buffer::Buffer, iterator::BytesIter};
 
 // AS DIGITS
 // ---------

--- a/lexical-util/src/not_feature_format.rs
+++ b/lexical-util/src/not_feature_format.rs
@@ -1,4 +1,5 @@
-//! Bare bones implementation of the format packed struct without feature `format`.
+//! Bare bones implementation of the format packed struct without feature
+//! `format`.
 //!
 //! See `feature_format` for detailed documentation.
 

--- a/lexical-util/src/num.rs
+++ b/lexical-util/src/num.rs
@@ -4,6 +4,8 @@
 //! types, and trait bounds, and conversions for working with
 //! numbers in generic code.
 
+#![cfg_attr(any(), rustfmt::skip)]
+
 use core::{fmt, mem, ops};
 
 #[cfg(feature = "f16")]
@@ -1243,27 +1245,36 @@ fn floorf(x: f32) -> f32 {
  * Return the logarithm of x
  *
  * Method :
- *   1. Argument Reduction: find k and f such that x = 2^k * (1+f), where
- *      sqrt(2)/2 < 1+f < sqrt(2) .
+ *   1. Argument Reduction: find k and f such that
+ *                      x = 2^k * (1+f),
+ *         where  sqrt(2)/2 < 1+f < sqrt(2) .
  *
- *   2. Approximation of log(1+f). Let s = f/(2+f) ; based on log(1+f) =
- *      log(1+s) - log(1-s) = 2s + 2/3 s**3 + 2/5 s**5 + ....., = 2s + s*R We
- *      use a special Remez algorithm on [0,0.1716] to generate a polynomial
- *      of degree 14 to approximate R The maximum error of this polynomial
- *      approximation is bounded by 2**-58.45. In other words, 2      4
- *      6      8      10      12      14 R(z) ~ Lg1*s +Lg2*s +Lg3*s +Lg4*s
- *      +Lg5*s  +Lg6*s  +Lg7*s (the values of Lg1 to Lg7 are listed in the
- *      program) and |      2          14          |     -58.45 | Lg1*s
- *      +...+Lg7*s    -  R(z) | <= 2 |                             | Note
- *      that 2s = f - s*f = f - hfsq + s*hfsq, where hfsq = f*f/2. In order
- *      to guarantee error in log below 1ulp, we compute log by log(1+f) = f
- *      - s*(f - R)        (if f is not too large) log(1+f) = f - (hfsq -
- *      s*(hfsq+R)).     (better accuracy)
+ *   2. Approximation of log(1+f).
+ *      Let s = f/(2+f) ; based on log(1+f) = log(1+s) - log(1-s)
+ *               = 2s + 2/3 s**3 + 2/5 s**5 + .....,
+ *               = 2s + s*R
+ *      We use a special Remez algorithm on [0,0.1716] to generate
+ *      a polynomial of degree 14 to approximate R The maximum error
+ *      of this polynomial approximation is bounded by 2**-58.45. In
+ *      other words,
+ *                      2      4      6      8      10      12      14
+ *          R(z) ~ Lg1*s +Lg2*s +Lg3*s +Lg4*s +Lg5*s  +Lg6*s  +Lg7*s
+ *      (the values of Lg1 to Lg7 are listed in the program)
+ *      and
+ *          |      2          14          |     -58.45
+ *          | Lg1*s +...+Lg7*s    -  R(z) | <= 2
+ *          |                             |
+ *      Note that 2s = f - s*f = f - hfsq + s*hfsq, where hfsq = f*f/2.
+ *      In order to guarantee error in log below 1ulp, we compute log
+ *      by
+ *              log(1+f) = f - s*(f - R)        (if f is not too large)
+ *              log(1+f) = f - (hfsq - s*(hfsq+R)).     (better accuracy)
  *
- *      3. Finally,  log(x) = k*ln2 + log(1+f). =
- *         k*ln2_hi+(f-(hfsq-(s*(hfsq+R)+k*ln2_lo))) Here ln2 is split into
- *         two floating point number: ln2_hi + ln2_lo, where n*ln2_hi is
- *         always exact for |n| < 2000.
+ *      3. Finally,  log(x) = k*ln2 + log(1+f).
+ *                          = k*ln2_hi+(f-(hfsq-(s*(hfsq+R)+k*ln2_lo)))
+ *         Here ln2 is split into two floating point number:
+ *                      ln2_hi + ln2_lo,
+ *         where n*ln2_hi is always exact for |n| < 2000.
  *
  * Special cases:
  *      log(x) is NaN with signal if x < 0 (including -INF) ;

--- a/lexical-util/src/result.rs
+++ b/lexical-util/src/result.rs
@@ -1,7 +1,8 @@
 //! Result type for numeric parsing functions.
 
-use crate::error;
 use core::result;
+
+use crate::error;
 
 /// A specialized Result type for lexical operations.
 pub type Result<T> = result::Result<T, error::Error>;

--- a/lexical-util/src/skip.rs
+++ b/lexical-util/src/skip.rs
@@ -10,12 +10,16 @@
 //! the number of permutations during parsing.
 //!
 //! We can consume any combinations of of \[0,3\] items from the following set:
-//!     - \[l\]eading digit separators, where digit separators occur before digits.
-//!     - \[i\]nternal digit separators, where digit separators occur between digits.
-//!     - \[t\]railing digit separators, where digit separators occur after digits.
+//!     - \[l\]eading digit separators, where digit separators occur before
+//!       digits.
+//!     - \[i\]nternal digit separators, where digit separators occur between
+//!       digits.
+//!     - \[t\]railing digit separators, where digit separators occur after
+//!       digits.
 //!
 //! In addition to those combinations, we can also have:
-//!     - \[c\]onsecutive digit separators, which allows two digit separators to be adjacent.
+//!     - \[c\]onsecutive digit separators, which allows two digit separators to
+//!       be adjacent.
 //!
 //! # Shorthand
 //!
@@ -37,12 +41,13 @@
 
 #![cfg(all(feature = "format", feature = "parse"))]
 
+use core::{mem, ptr};
+
 use crate::buffer::Buffer;
 use crate::digit::char_is_digit_const;
 use crate::format::NumberFormat;
 use crate::format_flags as flags;
 use crate::iterator::BytesIter;
-use core::{mem, ptr};
 
 // PEEK
 // ----
@@ -217,21 +222,24 @@ macro_rules! peek_t {
     };
 }
 
-/// Consumes at most 1 internal/leading digit separator and peeks the next value.
+/// Consumes at most 1 internal/leading digit separator and peeks the next
+/// value.
 macro_rules! peek_il {
     ($self:ident) => {
         peek_1!($self, is_il)
     };
 }
 
-/// Consumes at most 1 internal/trailing digit separator and peeks the next value.
+/// Consumes at most 1 internal/trailing digit separator and peeks the next
+/// value.
 macro_rules! peek_it {
     ($self:ident) => {
         peek_1!($self, is_it)
     };
 }
 
-/// Consumes at most 1 leading/trailing digit separator and peeks the next value.
+/// Consumes at most 1 leading/trailing digit separator and peeks the next
+/// value.
 macro_rules! peek_lt {
     ($self:ident) => {
         peek_1!($self, is_lt)
@@ -266,21 +274,24 @@ macro_rules! peek_tc {
     };
 }
 
-/// Consumes 1 or more internal/leading digit separators and peeks the next value.
+/// Consumes 1 or more internal/leading digit separators and peeks the next
+/// value.
 macro_rules! peek_ilc {
     ($self:ident) => {
         peek_n!($self, is_il)
     };
 }
 
-/// Consumes 1 or more internal/trailing digit separators and peeks the next value.
+/// Consumes 1 or more internal/trailing digit separators and peeks the next
+/// value.
 macro_rules! peek_itc {
     ($self:ident) => {
         peek_n!($self, is_it)
     };
 }
 
-/// Consumes 1 or more leading/trailing digit separators and peeks the next value.
+/// Consumes 1 or more leading/trailing digit separators and peeks the next
+/// value.
 macro_rules! peek_ltc {
     ($self:ident) => {
         peek_n!($self, is_lt)

--- a/lexical-util/src/step.rs
+++ b/lexical-util/src/step.rs
@@ -1,4 +1,5 @@
-//! The maximum digits that can be held in a u64 for a given radix without overflow.
+//! The maximum digits that can be held in a u64 for a given radix without
+//! overflow.
 //!
 //! This is useful for 128-bit division and operations, since it can
 //! reduces the number of inefficient, non-native operations.
@@ -139,8 +140,8 @@ pub const fn max_step(radix: u32, bits: usize, is_signed: bool) -> usize {
     }
 }
 
-/// Calculate the number of digits that can be processed without overflowing a u64.
-/// Helper function since this is used for 128-bit division.
+/// Calculate the number of digits that can be processed without overflowing a
+/// u64. Helper function since this is used for 128-bit division.
 #[inline(always)]
 pub const fn u64_step(radix: u32) -> usize {
     min_step(radix, 64, false)

--- a/lexical-util/src/step.rs
+++ b/lexical-util/src/step.rs
@@ -23,9 +23,13 @@
 /// without overflowing for a given type. For example, 19 digits can
 /// always be processed for a decimal string for `u64` without overflowing.
 #[inline(always)]
+#[allow(clippy::needless_return)]
 pub const fn min_step(radix: u32, bits: usize, is_signed: bool) -> usize {
-    if cfg!(feature = "radix") {
-        match radix {
+    // NOTE: to avoid branching when w don't need it, we use the compile logic
+
+    #[cfg(feature = "radix")]
+    {
+        return match radix {
             2 => min_step_2(bits, is_signed),
             3 => min_step_3(bits, is_signed),
             4 => min_step_4(bits, is_signed),
@@ -62,9 +66,12 @@ pub const fn min_step(radix: u32, bits: usize, is_signed: bool) -> usize {
             35 => min_step_35(bits, is_signed),
             36 => min_step_36(bits, is_signed),
             _ => 1,
-        }
-    } else if cfg!(feature = "power-of-two") {
-        match radix {
+        };
+    }
+
+    #[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+    {
+        return match radix {
             2 => min_step_2(bits, is_signed),
             4 => min_step_4(bits, is_signed),
             8 => min_step_8(bits, is_signed),
@@ -72,9 +79,13 @@ pub const fn min_step(radix: u32, bits: usize, is_signed: bool) -> usize {
             16 => min_step_16(bits, is_signed),
             32 => min_step_32(bits, is_signed),
             _ => 1,
-        }
-    } else {
-        min_step_10(bits, is_signed)
+        };
+    }
+
+    #[cfg(not(feature = "power-of-two"))]
+    {
+        _ = radix;
+        return min_step_10(bits, is_signed);
     }
 }
 
@@ -85,9 +96,11 @@ pub const fn min_step(radix: u32, bits: usize, is_signed: bool) -> usize {
 /// be processed for a decimal string for `u64` without overflowing, but
 /// it may overflow.
 #[inline(always)]
+#[allow(clippy::needless_return)]
 pub const fn max_step(radix: u32, bits: usize, is_signed: bool) -> usize {
-    if cfg!(feature = "radix") {
-        match radix {
+    #[cfg(feature = "radix")]
+    {
+        return match radix {
             2 => max_step_2(bits, is_signed),
             3 => max_step_3(bits, is_signed),
             4 => max_step_4(bits, is_signed),
@@ -124,9 +137,12 @@ pub const fn max_step(radix: u32, bits: usize, is_signed: bool) -> usize {
             35 => max_step_35(bits, is_signed),
             36 => max_step_36(bits, is_signed),
             _ => 1,
-        }
-    } else if cfg!(feature = "power-of-two") {
-        match radix {
+        };
+    }
+
+    #[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+    {
+        return match radix {
             2 => max_step_2(bits, is_signed),
             4 => max_step_4(bits, is_signed),
             8 => max_step_8(bits, is_signed),
@@ -134,9 +150,13 @@ pub const fn max_step(radix: u32, bits: usize, is_signed: bool) -> usize {
             16 => max_step_16(bits, is_signed),
             32 => max_step_32(bits, is_signed),
             _ => 1,
-        }
-    } else {
-        max_step_10(bits, is_signed)
+        };
+    }
+
+    #[cfg(not(feature = "power-of-two"))]
+    {
+        _ = radix;
+        return max_step_10(bits, is_signed);
     }
 }
 
@@ -157,6 +177,7 @@ pub const fn u64_step(radix: u32) -> usize {
 // recurse. Under normal circumstances, this will never be called.
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn max_step_2(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 7,
@@ -174,6 +195,7 @@ const fn max_step_2(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn min_step_2(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 7,
@@ -191,6 +213,7 @@ const fn min_step_2(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_3(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 5,
@@ -208,6 +231,7 @@ const fn max_step_3(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_3(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 4,
@@ -225,6 +249,7 @@ const fn min_step_3(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn max_step_4(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 4,
@@ -242,6 +267,7 @@ const fn max_step_4(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn min_step_4(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 3,
@@ -259,6 +285,7 @@ const fn min_step_4(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_5(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 4,
@@ -276,6 +303,7 @@ const fn max_step_5(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_5(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 3,
@@ -293,6 +321,7 @@ const fn min_step_5(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_6(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 3,
@@ -310,6 +339,7 @@ const fn max_step_6(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_6(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -327,6 +357,7 @@ const fn min_step_6(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_7(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 3,
@@ -344,6 +375,7 @@ const fn max_step_7(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_7(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -361,6 +393,7 @@ const fn min_step_7(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn max_step_8(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 3,
@@ -378,6 +411,7 @@ const fn max_step_8(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn min_step_8(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -395,6 +429,7 @@ const fn min_step_8(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_9(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 3,
@@ -412,6 +447,7 @@ const fn max_step_9(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_9(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -463,6 +499,7 @@ const fn min_step_10(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_11(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 3,
@@ -480,6 +517,7 @@ const fn max_step_11(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_11(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -497,6 +535,7 @@ const fn min_step_11(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_12(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -514,6 +553,7 @@ const fn max_step_12(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_12(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -531,6 +571,7 @@ const fn min_step_12(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_13(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -548,6 +589,7 @@ const fn max_step_13(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_13(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -565,6 +607,7 @@ const fn min_step_13(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_14(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -582,6 +625,7 @@ const fn max_step_14(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_14(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -599,6 +643,7 @@ const fn min_step_14(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_15(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -616,6 +661,7 @@ const fn max_step_15(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_15(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -633,6 +679,7 @@ const fn min_step_15(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn max_step_16(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -650,6 +697,7 @@ const fn max_step_16(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn min_step_16(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -667,6 +715,7 @@ const fn min_step_16(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_17(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -684,6 +733,7 @@ const fn max_step_17(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_17(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -701,6 +751,7 @@ const fn min_step_17(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_18(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -718,6 +769,7 @@ const fn max_step_18(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_18(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -735,6 +787,7 @@ const fn min_step_18(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_19(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -752,6 +805,7 @@ const fn max_step_19(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_19(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -769,6 +823,7 @@ const fn min_step_19(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_20(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -786,6 +841,7 @@ const fn max_step_20(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_20(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -803,6 +859,7 @@ const fn min_step_20(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_21(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -820,6 +877,7 @@ const fn max_step_21(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_21(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -837,6 +895,7 @@ const fn min_step_21(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_22(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -854,6 +913,7 @@ const fn max_step_22(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_22(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -871,6 +931,7 @@ const fn min_step_22(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_23(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -888,6 +949,7 @@ const fn max_step_23(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_23(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -905,6 +967,7 @@ const fn min_step_23(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_24(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -922,6 +985,7 @@ const fn max_step_24(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_24(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -939,6 +1003,7 @@ const fn min_step_24(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_25(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -956,6 +1021,7 @@ const fn max_step_25(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_25(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -973,6 +1039,7 @@ const fn min_step_25(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_26(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -990,6 +1057,7 @@ const fn max_step_26(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_26(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1007,6 +1075,7 @@ const fn min_step_26(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_27(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1024,6 +1093,7 @@ const fn max_step_27(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_27(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1041,6 +1111,7 @@ const fn min_step_27(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_28(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1058,6 +1129,7 @@ const fn max_step_28(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_28(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1075,6 +1147,7 @@ const fn min_step_28(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_29(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1092,6 +1165,7 @@ const fn max_step_29(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_29(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1109,6 +1183,7 @@ const fn min_step_29(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_30(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1126,6 +1201,7 @@ const fn max_step_30(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_30(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1143,6 +1219,7 @@ const fn min_step_30(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_31(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1160,6 +1237,7 @@ const fn max_step_31(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_31(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1177,6 +1255,7 @@ const fn min_step_31(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn max_step_32(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1194,6 +1273,7 @@ const fn max_step_32(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "power-of-two"), allow(dead_code))]
 const fn min_step_32(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1211,6 +1291,7 @@ const fn min_step_32(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_33(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1228,6 +1309,7 @@ const fn max_step_33(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_33(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1245,6 +1327,7 @@ const fn min_step_33(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_34(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1262,6 +1345,7 @@ const fn max_step_34(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_34(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1279,6 +1363,7 @@ const fn min_step_34(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_35(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1296,6 +1381,7 @@ const fn max_step_35(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_35(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,
@@ -1313,6 +1399,7 @@ const fn min_step_35(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn max_step_36(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 2,
@@ -1330,6 +1417,7 @@ const fn max_step_36(bits: usize, is_signed: bool) -> usize {
 }
 
 #[inline(always)]
+#[cfg_attr(not(feature = "radix"), allow(dead_code))]
 const fn min_step_36(bits: usize, is_signed: bool) -> usize {
     match bits {
         8 if is_signed => 1,

--- a/lexical-util/tests/bf16_tests.rs
+++ b/lexical-util/tests/bf16_tests.rs
@@ -2,10 +2,11 @@
 
 mod util;
 
-use crate::util::default_proptest_config;
 use lexical_util::bf16::bf16;
 use lexical_util::num::Float;
 use proptest::prelude::*;
+
+use crate::util::default_proptest_config;
 
 #[test]
 fn as_f32_test() {

--- a/lexical-util/tests/div128_tests.rs
+++ b/lexical-util/tests/div128_tests.rs
@@ -3,10 +3,11 @@
 
 mod util;
 
-use crate::util::default_proptest_config;
 use lexical_util::div128::u128_divrem;
 use lexical_util::step::u64_step;
 use proptest::{prop_assert_eq, proptest};
+
+use crate::util::default_proptest_config;
 
 proptest! {
     #![proptest_config(default_proptest_config())]

--- a/lexical-util/tests/f16_tests.rs
+++ b/lexical-util/tests/f16_tests.rs
@@ -2,10 +2,11 @@
 
 mod util;
 
-use crate::util::default_proptest_config;
 use lexical_util::f16::f16;
 use lexical_util::num::Float;
 use proptest::prelude::*;
+
+use crate::util::default_proptest_config;
 
 #[test]
 fn as_f32_test() {

--- a/lexical-util/tests/feature_format_tests.rs
+++ b/lexical-util/tests/feature_format_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "format")]
 
 use core::num;
+
 use lexical_util::format;
 
 #[test]

--- a/lexical-util/tests/format_flags_tests.rs
+++ b/lexical-util/tests/format_flags_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "format")]
 use core::num;
+
 #[cfg(feature = "format")]
 use lexical_util::format;
 

--- a/lexical-util/tests/iterator_tests.rs
+++ b/lexical-util/tests/iterator_tests.rs
@@ -61,6 +61,7 @@ fn digits_iterator_test() {
 #[cfg(feature = "format")]
 fn skip_iterator_test() {
     use core::num;
+
     use lexical_util::format::{NumberFormat, NumberFormatBuilder};
     use static_assertions::const_assert;
 

--- a/lexical-util/tests/skip_tests.rs
+++ b/lexical-util/tests/skip_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(all(feature = "format", feature = "parse"))]
 
 use core::num;
+
 use lexical_util::format::{NumberFormat, NumberFormatBuilder};
 use lexical_util::iterator::AsBytes;
 use static_assertions::const_assert;

--- a/lexical-util/tests/util.rs
+++ b/lexical-util/tests/util.rs
@@ -24,8 +24,8 @@ pub fn default_proptest_config() -> ProptestConfig {
     }
 }
 
-// This is almost identical to quickcheck's itself, just to add default arguments
-//  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
+// This is almost identical to quickcheck's itself, just to add default
+// arguments  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
 // The code is unlicensed.
 #[macro_export]
 macro_rules! default_quickcheck {

--- a/lexical-write-float/src/api.rs
+++ b/lexical-write-float/src/api.rs
@@ -2,8 +2,6 @@
 
 #![doc(hidden)]
 
-use crate::options::Options;
-use crate::write::WriteFloat;
 #[cfg(feature = "f16")]
 use lexical_util::bf16::bf16;
 use lexical_util::constants::FormattedSize;
@@ -12,6 +10,9 @@ use lexical_util::f16::f16;
 use lexical_util::format::STANDARD;
 use lexical_util::options::WriteOptions;
 use lexical_util::{to_lexical, to_lexical_with_options};
+
+use crate::options::Options;
+use crate::write::WriteFloat;
 
 /// Check if a buffer is sufficiently large.
 #[inline(always)]

--- a/lexical-write-float/src/binary.rs
+++ b/lexical-write-float/src/binary.rs
@@ -7,13 +7,14 @@
 #![cfg(feature = "power-of-two")]
 #![doc(hidden)]
 
-use crate::options::{Options, RoundMode};
-use crate::shared;
 use lexical_util::algorithm::rtrim_char_count;
 use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
 use lexical_util::format::NumberFormat;
 use lexical_util::num::{as_cast, Float, Integer, UnsignedInteger};
 use lexical_write_integer::write::WriteInteger;
+
+use crate::options::{Options, RoundMode};
+use crate::shared;
 
 /// Optimized float-to-string algorithm for power of 2 radixes.
 ///
@@ -242,7 +243,8 @@ where
     let shl = calculate_shl(exp, bits_per_digit);
     let value = mantissa << shl;
 
-    // SAFETY: both are safe, if the buffer is large enough to hold the significant digits.
+    // SAFETY: both are safe, if the buffer is large enough to hold the significant
+    // digits.
     let digit_count = unsafe {
         let count = value.write_mantissa::<M, FORMAT>(&mut index_unchecked_mut!(bytes[cursor..]));
         let zeros = rtrim_char_count(&index_unchecked!(bytes[cursor..cursor + count]), b'0');
@@ -313,7 +315,8 @@ where
     let leading_bits = sci_exp;
     let leading_digits = (leading_bits / bits_per_digit) as usize + 1;
 
-    // Now need to write our decimal point and add any additional significant digits.
+    // Now need to write our decimal point and add any additional significant
+    // digits.
     let mut cursor: usize;
     let mut trimmed = false;
     if leading_digits >= digit_count {

--- a/lexical-write-float/src/compact.rs
+++ b/lexical-write-float/src/compact.rs
@@ -15,16 +15,13 @@
 //! 1. The exponent is inferred, rather than explicitly store.
 //! 2. The mantissas are stored in hex, rather than decimal.
 //! 3. Forcing and disabling exponent notation is now supported.
-//! 4. Controlling the maximum and minimum number of significant digits is supported.
+//! 4. Controlling the maximum and minimum number of significant digits is
+//!    supported.
 //! 5. Support for trimming floats (".0") is also included.
 
 #![cfg(feature = "compact")]
 #![doc(hidden)]
 
-use crate::float::{ExtendedFloat80, RawFloat};
-use crate::options::Options;
-use crate::shared;
-use crate::table::GRISU_POWERS_OF_TEN;
 use lexical_util::algorithm::rtrim_char_count;
 #[cfg(feature = "f16")]
 use lexical_util::bf16::bf16;
@@ -33,6 +30,11 @@ use lexical_util::digit::digit_to_char_const;
 use lexical_util::f16::f16;
 use lexical_util::format::NumberFormat;
 use lexical_util::num::{AsPrimitive, Float};
+
+use crate::float::{ExtendedFloat80, RawFloat};
+use crate::options::Options;
+use crate::shared;
+use crate::table::GRISU_POWERS_OF_TEN;
 
 /// Compact float-to-string algorithm for decimal strings.
 ///
@@ -191,7 +193,8 @@ pub unsafe fn write_float_negative_exponent<const FORMAT: u128>(
     let mut cursor = sci_exp + 1;
 
     // Write out significant digits.
-    // SAFETY: safe if the buffer is large enough to hold all the significant digits.
+    // SAFETY: safe if the buffer is large enough to hold all the significant
+    // digits.
     unsafe {
         let src = digits.as_ptr();
         let dst = &mut bytes[cursor..cursor + digit_count];
@@ -503,7 +506,8 @@ pub fn normalized_boundaries<F: Float>(fp: &ExtendedFloat80) -> (ExtendedFloat80
 /// set. The result is not normalized.
 ///
 /// Algorithm:
-///     1. Non-signed multiplication of mantissas (requires 2x as many bits as input).
+///     1. Non-signed multiplication of mantissas (requires 2x as many bits as
+///        input).
 ///     2. Normalization of the result (not done here).
 ///     3. Addition of exponents.
 pub fn mul(x: &ExtendedFloat80, y: &ExtendedFloat80) -> ExtendedFloat80 {

--- a/lexical-write-float/src/float.rs
+++ b/lexical-write-float/src/float.rs
@@ -4,15 +4,16 @@
 
 #![doc(hidden)]
 
-#[cfg(not(feature = "compact"))]
-use crate::algorithm::DragonboxFloat;
-#[cfg(feature = "compact")]
-use crate::compact::GrisuFloat;
 #[cfg(feature = "f16")]
 use lexical_util::bf16::bf16;
 use lexical_util::extended_float::ExtendedFloat;
 #[cfg(feature = "f16")]
 use lexical_util::f16::f16;
+
+#[cfg(not(feature = "compact"))]
+use crate::algorithm::DragonboxFloat;
+#[cfg(feature = "compact")]
+use crate::compact::GrisuFloat;
 
 /// Alias with ~80 bits of precision, 64 for the mantissa and 16 for exponent.
 /// This exponent is biased, and if the exponent is negative, it represents

--- a/lexical-write-float/src/hex.rs
+++ b/lexical-write-float/src/hex.rs
@@ -17,6 +17,12 @@
 #![cfg(feature = "power-of-two")]
 #![doc(hidden)]
 
+use lexical_util::algorithm::rtrim_char_count;
+use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
+use lexical_util::format::NumberFormat;
+use lexical_util::num::{Float, Integer};
+use lexical_write_integer::write::WriteInteger;
+
 use crate::binary::{
     calculate_shl,
     fast_ceildiv,
@@ -27,11 +33,6 @@ use crate::binary::{
 };
 use crate::options::Options;
 use crate::shared;
-use lexical_util::algorithm::rtrim_char_count;
-use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
-use lexical_util::format::NumberFormat;
-use lexical_util::num::{Float, Integer};
-use lexical_write_integer::write::WriteInteger;
 
 /// Optimized float-to-string algorithm for hexadecimal strings.
 ///

--- a/lexical-write-float/src/lib.rs
+++ b/lexical-write-float/src/lib.rs
@@ -15,7 +15,8 @@
 //!
 //! 1. Compact for decimal strings uses the Grisu algorithm.
 //! 2. An optimized algorithm based on the Dragonbox algorithm.
-//! 3. An optimized algorithm for formatting to string with power-of-two radixes.
+//! 3. An optimized algorithm for formatting to string with power-of-two
+//!    radixes.
 //! 4. An optimized algorithm for hexadecimal floats.
 //! 5. A fallback algorithm for all other radixes.
 //!
@@ -89,9 +90,6 @@ mod table_dragonbox;
 mod table_grisu;
 
 // Re-exports
-pub use self::api::{ToLexical, ToLexicalWithOptions};
-#[doc(inline)]
-pub use self::options::{Options, OptionsBuilder, RoundMode};
 #[cfg(feature = "f16")]
 pub use lexical_util::bf16::bf16;
 pub use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
@@ -99,3 +97,7 @@ pub use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
 pub use lexical_util::f16::f16;
 pub use lexical_util::format::{self, NumberFormatBuilder};
 pub use lexical_util::options::WriteOptions;
+
+pub use self::api::{ToLexical, ToLexicalWithOptions};
+#[doc(inline)]
+pub use self::options::{Options, OptionsBuilder, RoundMode};

--- a/lexical-write-float/src/options.rs
+++ b/lexical-write-float/src/options.rs
@@ -1,6 +1,7 @@
 //! Configuration options for writing floats.
 
 use core::{mem, num};
+
 use lexical_util::ascii::{is_valid_ascii, is_valid_letter_slice};
 use lexical_util::constants::FormattedSize;
 use lexical_util::error::Error;
@@ -22,7 +23,8 @@ const_assert!(mem::size_of::<OptionI32>() == mem::size_of::<i32>());
 /// Enumeration for how to round floats with precision control.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RoundMode {
-    /// Round to the nearest float string with the given number of significant digits.
+    /// Round to the nearest float string with the given number of significant
+    /// digits.
     Round,
     /// Truncate the float string with the given number of significant digits.
     Truncate,
@@ -46,12 +48,12 @@ pub struct OptionsBuilder {
     /// `0.100000000000000000000000`, which is still the nearest float.
     min_significant_digits: OptionUsize,
     /// Maximum exponent prior to using scientific notation.
-    /// This is ignored if the exponent base is not the same as the mantissa radix.
-    /// If not provided, use the algorithm's default.
+    /// This is ignored if the exponent base is not the same as the mantissa
+    /// radix. If not provided, use the algorithm's default.
     positive_exponent_break: OptionI32,
     /// Minimum exponent prior to using scientific notation.
-    /// This is ignored if the exponent base is not the same as the mantissa radix.
-    /// If not provided, use the algorithm's default.
+    /// This is ignored if the exponent base is not the same as the mantissa
+    /// radix. If not provided, use the algorithm's default.
     negative_exponent_break: OptionI32,
     /// Rounding mode for writing digits with precision control.
     round_mode: RoundMode,
@@ -382,12 +384,12 @@ pub struct Options {
     /// If not set, it defaults to the algorithm's default.
     min_significant_digits: OptionUsize,
     /// Maximum exponent prior to using scientific notation.
-    /// This is ignored if the exponent base is not the same as the mantissa radix.
-    /// If not provided, use the algorithm's default.
+    /// This is ignored if the exponent base is not the same as the mantissa
+    /// radix. If not provided, use the algorithm's default.
     positive_exponent_break: OptionI32,
     /// Minimum exponent prior to using scientific notation.
-    /// This is ignored if the exponent base is not the same as the mantissa radix.
-    /// If not provided, use the algorithm's default.
+    /// This is ignored if the exponent base is not the same as the mantissa
+    /// radix. If not provided, use the algorithm's default.
     negative_exponent_break: OptionI32,
     /// Rounding mode for writing digits with precision control.
     round_mode: RoundMode,

--- a/lexical-write-float/src/radix.rs
+++ b/lexical-write-float/src/radix.rs
@@ -12,14 +12,15 @@
 #![cfg(feature = "radix")]
 #![doc(hidden)]
 
-use crate::options::{Options, RoundMode};
-use crate::shared;
 use lexical_util::algorithm::{ltrim_char_count, rtrim_char_count};
 use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
 use lexical_util::digit::{char_to_digit_const, digit_to_char_const};
 use lexical_util::format::NumberFormat;
 use lexical_util::num::Float;
 use lexical_write_integer::write::WriteInteger;
+
+use crate::options::{Options, RoundMode};
+use crate::shared;
 
 // ALGORITHM
 // ---------
@@ -278,7 +279,8 @@ pub unsafe fn write_float_scientific<const FORMAT: u128>(
     }
 
     // Now, write our scientific notation.
-    // SAFETY: safe if bytes is large enough to store the largest float with the smallest radix.
+    // SAFETY: safe if bytes is large enough to store the largest float with the
+    // smallest radix.
     unsafe { shared::write_exponent::<FORMAT>(bytes, &mut cursor, sci_exp, options.exponent()) };
 
     cursor
@@ -356,7 +358,8 @@ pub unsafe fn write_float_nonscientific<const FORMAT: u128>(
     // Write the fraction component.
     // We've only consumed `integer_count` digits, since this input
     // may have been truncated.
-    // SAFETY: safe since `integer_count < digits.len()` since `digit_count < digits.len()`.
+    // SAFETY: safe since `integer_count < digits.len()` since `digit_count <
+    // digits.len()`.
     let digits = unsafe { &index_unchecked!(digits[integer_count..]) };
     let fraction_count = digit_count.saturating_sub(integer_length);
     if fraction_count > 0 {
@@ -486,7 +489,8 @@ pub unsafe fn truncate_and_round(
             (max_digits, false)
         } else {
             // Above halfway or at halfway and even, round-up
-            // SAFETY: safe if `digit_count <= digits.len()`, because `max_digits < digit_count`.
+            // SAFETY: safe if `digit_count <= digits.len()`, because `max_digits <
+            // digit_count`.
             let digits = unsafe { &mut index_unchecked_mut!(buffer[start..start + max_digits]) };
             unsafe { shared::round_up(digits, max_digits, radix) }
         }

--- a/lexical-write-float/src/shared.rs
+++ b/lexical-write-float/src/shared.rs
@@ -1,9 +1,10 @@
 //! Shared utilities for writing floats.
 
-use crate::options::{Options, RoundMode};
 use lexical_util::digit::{char_to_valid_digit_const, digit_to_char_const};
 use lexical_util::format::NumberFormat;
 use lexical_write_integer::write::WriteInteger;
+
+use crate::options::{Options, RoundMode};
 
 /// Get the exact number of digits from a minimum bound.
 #[inline(always)]
@@ -90,14 +91,16 @@ pub unsafe fn truncate_and_round_decimal(
     // halfway at all, we need to round up, even if 1 digit.
 
     // Get the last non-truncated digit, and the remaining ones.
-    // SAFETY: safe if `digit_count < digits.len()`, since `max_digits < digit_count`.
+    // SAFETY: safe if `digit_count < digits.len()`, since `max_digits <
+    // digit_count`.
     let truncated = unsafe { index_unchecked!(digits[max_digits]) };
     let (digits, carried) = if truncated < b'5' {
         // Just truncate, going to round-down anyway.
         (max_digits, false)
     } else if truncated > b'5' {
         // Round-up always.
-        // SAFETY: safe if `digit_count <= digits.len()`, because `max_digits < digit_count`.
+        // SAFETY: safe if `digit_count <= digits.len()`, because `max_digits <
+        // digit_count`.
         unsafe { round_up(digits, max_digits, 10) }
     } else {
         // Have a near-halfway case, resolve it.
@@ -109,7 +112,8 @@ pub unsafe fn truncate_and_round_decimal(
             (is_odd, is_above)
         };
         if is_odd || is_above {
-            // SAFETY: safe if `digit_count <= digits.len()`, because `max_digits < digit_count`.
+            // SAFETY: safe if `digit_count <= digits.len()`, because `max_digits <
+            // digit_count`.
             unsafe { round_up(digits, max_digits, 10) }
         } else {
             (max_digits, false)
@@ -168,7 +172,8 @@ pub unsafe fn write_exponent<const FORMAT: u128>(
     };
 }
 
-/// Detect the notation to use for the float formatter and call the appropriate function.
+/// Detect the notation to use for the float formatter and call the appropriate
+/// function.
 ///
 /// - `float` - The float to write to string.
 /// - `format` - The formatting specification for the float.

--- a/lexical-write-float/src/write.rs
+++ b/lexical-write-float/src/write.rs
@@ -2,20 +2,6 @@
 
 #![doc(hidden)]
 
-#[cfg(not(feature = "compact"))]
-use crate::algorithm::write_float as write_float_decimal;
-#[cfg(feature = "power-of-two")]
-use crate::binary;
-/// Select the back-end.
-#[cfg(feature = "compact")]
-use crate::compact::write_float as write_float_decimal;
-#[cfg(feature = "power-of-two")]
-use crate::hex;
-#[cfg(feature = "radix")]
-use crate::radix;
-
-use crate::float::RawFloat;
-use crate::options::Options;
 #[cfg(feature = "f16")]
 use lexical_util::bf16::bf16;
 use lexical_util::constants::FormattedSize;
@@ -23,6 +9,20 @@ use lexical_util::constants::FormattedSize;
 use lexical_util::f16::f16;
 use lexical_util::format::NumberFormat;
 use lexical_write_integer::write::WriteInteger;
+
+#[cfg(not(feature = "compact"))]
+use crate::algorithm::write_float as write_float_decimal;
+#[cfg(feature = "power-of-two")]
+use crate::binary;
+/// Select the back-end.
+#[cfg(feature = "compact")]
+use crate::compact::write_float as write_float_decimal;
+use crate::float::RawFloat;
+#[cfg(feature = "power-of-two")]
+use crate::hex;
+use crate::options::Options;
+#[cfg(feature = "radix")]
+use crate::radix;
 
 /// Write float trait.
 pub trait WriteFloat: RawFloat {

--- a/lexical-write-float/tests/algorithm_tests.rs
+++ b/lexical-write-float/tests/algorithm_tests.rs
@@ -2,8 +2,8 @@
 
 mod util;
 
-use crate::util::default_proptest_config;
 use core::num;
+
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_util::format::NumberFormatBuilder;
 use lexical_util::num::Float;
@@ -11,6 +11,8 @@ use lexical_write_float::algorithm::DragonboxFloat;
 use lexical_write_float::float::{ExtendedFloat80, RawFloat};
 use lexical_write_float::{algorithm, Options, RoundMode};
 use proptest::prelude::*;
+
+use crate::util::default_proptest_config;
 
 const DECIMAL: u128 = NumberFormatBuilder::decimal();
 

--- a/lexical-write-float/tests/api_tests.rs
+++ b/lexical-write-float/tests/api_tests.rs
@@ -1,6 +1,5 @@
 mod util;
 
-use crate::util::default_proptest_config;
 #[cfg(feature = "f16")]
 use lexical_util::bf16::bf16;
 use lexical_util::constants::BUFFER_SIZE;
@@ -9,6 +8,8 @@ use lexical_util::f16::f16;
 use lexical_util::format::STANDARD;
 use lexical_write_float::{Options, ToLexical, ToLexicalWithOptions};
 use proptest::prelude::*;
+
+use crate::util::default_proptest_config;
 
 #[test]
 fn error_tests() {
@@ -71,6 +72,7 @@ fn invalid_inf_test() {
 #[cfg(feature = "power-of-two")]
 fn hex_test() {
     use core::num;
+
     use lexical_util::format::NumberFormatBuilder;
 
     const BASE16_2_10: u128 = NumberFormatBuilder::new()

--- a/lexical-write-float/tests/binary_tests.rs
+++ b/lexical-write-float/tests/binary_tests.rs
@@ -3,8 +3,8 @@
 mod parse_radix;
 mod util;
 
-use crate::util::default_proptest_config;
 use core::num;
+
 use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
 use lexical_util::format::NumberFormatBuilder;
 use lexical_util::num::{Float, Integer};
@@ -13,6 +13,8 @@ use lexical_write_float::{binary, Options};
 use lexical_write_integer::write::WriteInteger;
 use parse_radix::{parse_f32, parse_f64};
 use proptest::prelude::*;
+
+use crate::util::default_proptest_config;
 
 const BINARY: u128 = NumberFormatBuilder::binary();
 const BASE4: u128 = NumberFormatBuilder::from_radix(4);

--- a/lexical-write-float/tests/compact_tests.rs
+++ b/lexical-write-float/tests/compact_tests.rs
@@ -2,14 +2,16 @@
 
 mod util;
 
-use crate::util::default_proptest_config;
 use core::num;
+
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_util::format::NumberFormatBuilder;
 use lexical_util::num::Float;
 use lexical_write_float::float::{ExtendedFloat80, RawFloat};
 use lexical_write_float::{compact, Options, RoundMode};
 use proptest::prelude::*;
+
+use crate::util::default_proptest_config;
 
 const DECIMAL: u128 = NumberFormatBuilder::decimal();
 
@@ -23,13 +25,10 @@ fn check_normalize(mant: u64, exp: i32, ymant: u64, yexp: i32) {
         compact::normalize(&mut x);
         assert_eq!(x.mant & (1 << 63), 1 << 63);
     }
-    assert_eq!(
-        x,
-        ExtendedFloat80 {
-            mant: ymant,
-            exp: yexp
-        }
-    );
+    assert_eq!(x, ExtendedFloat80 {
+        mant: ymant,
+        exp: yexp
+    });
 }
 
 #[test]
@@ -85,227 +84,134 @@ fn normalized_boundaries_test() {
 
 #[test]
 fn from_f32_test() {
-    assert_eq!(
-        compact::from_float(0.0f32),
-        ExtendedFloat80 {
-            mant: 0,
-            exp: -149
-        }
-    );
-    assert_eq!(
-        compact::from_float(-0.0f32),
-        ExtendedFloat80 {
-            mant: 0,
-            exp: -149
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e-45f32),
-        ExtendedFloat80 {
-            mant: 1,
-            exp: -149
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e-40f32),
-        ExtendedFloat80 {
-            mant: 71362,
-            exp: -149
-        }
-    );
-    assert_eq!(
-        compact::from_float(2e-40f32),
-        ExtendedFloat80 {
-            mant: 142725,
-            exp: -149
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e-20f32),
-        ExtendedFloat80 {
-            mant: 12379400,
-            exp: -90
-        }
-    );
-    assert_eq!(
-        compact::from_float(2e-20f32),
-        ExtendedFloat80 {
-            mant: 12379400,
-            exp: -89
-        }
-    );
-    assert_eq!(
-        compact::from_float(1.0f32),
-        ExtendedFloat80 {
-            mant: 8388608,
-            exp: -23
-        }
-    );
-    assert_eq!(
-        compact::from_float(2.0f32),
-        ExtendedFloat80 {
-            mant: 8388608,
-            exp: -22
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e20f32),
-        ExtendedFloat80 {
-            mant: 11368684,
-            exp: 43
-        }
-    );
-    assert_eq!(
-        compact::from_float(2e20f32),
-        ExtendedFloat80 {
-            mant: 11368684,
-            exp: 44
-        }
-    );
-    assert_eq!(
-        compact::from_float(3.402823e38f32),
-        ExtendedFloat80 {
-            mant: 16777213,
-            exp: 104
-        }
-    );
+    assert_eq!(compact::from_float(0.0f32), ExtendedFloat80 {
+        mant: 0,
+        exp: -149
+    });
+    assert_eq!(compact::from_float(-0.0f32), ExtendedFloat80 {
+        mant: 0,
+        exp: -149
+    });
+    assert_eq!(compact::from_float(1e-45f32), ExtendedFloat80 {
+        mant: 1,
+        exp: -149
+    });
+    assert_eq!(compact::from_float(1e-40f32), ExtendedFloat80 {
+        mant: 71362,
+        exp: -149
+    });
+    assert_eq!(compact::from_float(2e-40f32), ExtendedFloat80 {
+        mant: 142725,
+        exp: -149
+    });
+    assert_eq!(compact::from_float(1e-20f32), ExtendedFloat80 {
+        mant: 12379400,
+        exp: -90
+    });
+    assert_eq!(compact::from_float(2e-20f32), ExtendedFloat80 {
+        mant: 12379400,
+        exp: -89
+    });
+    assert_eq!(compact::from_float(1.0f32), ExtendedFloat80 {
+        mant: 8388608,
+        exp: -23
+    });
+    assert_eq!(compact::from_float(2.0f32), ExtendedFloat80 {
+        mant: 8388608,
+        exp: -22
+    });
+    assert_eq!(compact::from_float(1e20f32), ExtendedFloat80 {
+        mant: 11368684,
+        exp: 43
+    });
+    assert_eq!(compact::from_float(2e20f32), ExtendedFloat80 {
+        mant: 11368684,
+        exp: 44
+    });
+    assert_eq!(compact::from_float(3.402823e38f32), ExtendedFloat80 {
+        mant: 16777213,
+        exp: 104
+    });
 }
 
 #[test]
 fn from_f64_test() {
-    assert_eq!(
-        compact::from_float(0.0f64),
-        ExtendedFloat80 {
-            mant: 0,
-            exp: -1074
-        }
-    );
-    assert_eq!(
-        compact::from_float(-0.0f64),
-        ExtendedFloat80 {
-            mant: 0,
-            exp: -1074
-        }
-    );
-    assert_eq!(
-        compact::from_float(5e-324f64),
-        ExtendedFloat80 {
-            mant: 1,
-            exp: -1074
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e-250f64),
-        ExtendedFloat80 {
-            mant: 6448907850777164,
-            exp: -883
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e-150f64),
-        ExtendedFloat80 {
-            mant: 7371020360979573,
-            exp: -551
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e-45f64),
-        ExtendedFloat80 {
-            mant: 6427752177035961,
-            exp: -202
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e-40f64),
-        ExtendedFloat80 {
-            mant: 4903985730770844,
-            exp: -185
-        }
-    );
-    assert_eq!(
-        compact::from_float(2e-40f64),
-        ExtendedFloat80 {
-            mant: 4903985730770844,
-            exp: -184
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e-20f64),
-        ExtendedFloat80 {
-            mant: 6646139978924579,
-            exp: -119
-        }
-    );
-    assert_eq!(
-        compact::from_float(2e-20f64),
-        ExtendedFloat80 {
-            mant: 6646139978924579,
-            exp: -118
-        }
-    );
-    assert_eq!(
-        compact::from_float(1.0f64),
-        ExtendedFloat80 {
-            mant: 4503599627370496,
-            exp: -52
-        }
-    );
-    assert_eq!(
-        compact::from_float(2.0f64),
-        ExtendedFloat80 {
-            mant: 4503599627370496,
-            exp: -51
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e20f64),
-        ExtendedFloat80 {
-            mant: 6103515625000000,
-            exp: 14
-        }
-    );
-    assert_eq!(
-        compact::from_float(2e20f64),
-        ExtendedFloat80 {
-            mant: 6103515625000000,
-            exp: 15
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e40f64),
-        ExtendedFloat80 {
-            mant: 8271806125530277,
-            exp: 80
-        }
-    );
-    assert_eq!(
-        compact::from_float(2e40f64),
-        ExtendedFloat80 {
-            mant: 8271806125530277,
-            exp: 81
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e150f64),
-        ExtendedFloat80 {
-            mant: 5503284107318959,
-            exp: 446
-        }
-    );
-    assert_eq!(
-        compact::from_float(1e250f64),
-        ExtendedFloat80 {
-            mant: 6290184345309700,
-            exp: 778
-        }
-    );
-    assert_eq!(
-        compact::from_float(1.7976931348623157e308),
-        ExtendedFloat80 {
-            mant: 9007199254740991,
-            exp: 971
-        }
-    );
+    assert_eq!(compact::from_float(0.0f64), ExtendedFloat80 {
+        mant: 0,
+        exp: -1074
+    });
+    assert_eq!(compact::from_float(-0.0f64), ExtendedFloat80 {
+        mant: 0,
+        exp: -1074
+    });
+    assert_eq!(compact::from_float(5e-324f64), ExtendedFloat80 {
+        mant: 1,
+        exp: -1074
+    });
+    assert_eq!(compact::from_float(1e-250f64), ExtendedFloat80 {
+        mant: 6448907850777164,
+        exp: -883
+    });
+    assert_eq!(compact::from_float(1e-150f64), ExtendedFloat80 {
+        mant: 7371020360979573,
+        exp: -551
+    });
+    assert_eq!(compact::from_float(1e-45f64), ExtendedFloat80 {
+        mant: 6427752177035961,
+        exp: -202
+    });
+    assert_eq!(compact::from_float(1e-40f64), ExtendedFloat80 {
+        mant: 4903985730770844,
+        exp: -185
+    });
+    assert_eq!(compact::from_float(2e-40f64), ExtendedFloat80 {
+        mant: 4903985730770844,
+        exp: -184
+    });
+    assert_eq!(compact::from_float(1e-20f64), ExtendedFloat80 {
+        mant: 6646139978924579,
+        exp: -119
+    });
+    assert_eq!(compact::from_float(2e-20f64), ExtendedFloat80 {
+        mant: 6646139978924579,
+        exp: -118
+    });
+    assert_eq!(compact::from_float(1.0f64), ExtendedFloat80 {
+        mant: 4503599627370496,
+        exp: -52
+    });
+    assert_eq!(compact::from_float(2.0f64), ExtendedFloat80 {
+        mant: 4503599627370496,
+        exp: -51
+    });
+    assert_eq!(compact::from_float(1e20f64), ExtendedFloat80 {
+        mant: 6103515625000000,
+        exp: 14
+    });
+    assert_eq!(compact::from_float(2e20f64), ExtendedFloat80 {
+        mant: 6103515625000000,
+        exp: 15
+    });
+    assert_eq!(compact::from_float(1e40f64), ExtendedFloat80 {
+        mant: 8271806125530277,
+        exp: 80
+    });
+    assert_eq!(compact::from_float(2e40f64), ExtendedFloat80 {
+        mant: 8271806125530277,
+        exp: 81
+    });
+    assert_eq!(compact::from_float(1e150f64), ExtendedFloat80 {
+        mant: 5503284107318959,
+        exp: 446
+    });
+    assert_eq!(compact::from_float(1e250f64), ExtendedFloat80 {
+        mant: 6290184345309700,
+        exp: 778
+    });
+    assert_eq!(compact::from_float(1.7976931348623157e308), ExtendedFloat80 {
+        mant: 9007199254740991,
+        exp: 971
+    });
 }
 
 fn check_mul(xmant: u64, xexp: i32, ymant: u64, yexp: i32, zmant: u64, zexp: i32) {

--- a/lexical-write-float/tests/hex_tests.rs
+++ b/lexical-write-float/tests/hex_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "power-of-two")]
 
 use core::num;
+
 use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
 use lexical_util::format::NumberFormatBuilder;
 use lexical_util::num::{Float, Integer};

--- a/lexical-write-float/tests/options_tests.rs
+++ b/lexical-write-float/tests/options_tests.rs
@@ -1,4 +1,5 @@
 use core::num;
+
 use lexical_write_float::options::{self, Options, OptionsBuilder};
 
 #[test]

--- a/lexical-write-float/tests/radix_tests.rs
+++ b/lexical-write-float/tests/radix_tests.rs
@@ -3,9 +3,9 @@
 mod parse_radix;
 mod util;
 
-use crate::util::default_proptest_config;
-use approx::{assert_relative_eq, relative_eq};
 use core::num;
+
+use approx::{assert_relative_eq, relative_eq};
 use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
 use lexical_util::format::NumberFormatBuilder;
 use lexical_util::num::Float;
@@ -14,6 +14,8 @@ use lexical_write_float::{radix, Options};
 use lexical_write_integer::write::WriteInteger;
 use parse_radix::{parse_f32, parse_f64};
 use proptest::prelude::*;
+
+use crate::util::default_proptest_config;
 
 const BASE3: u128 = NumberFormatBuilder::from_radix(3);
 const BASE5: u128 = NumberFormatBuilder::from_radix(5);

--- a/lexical-write-float/tests/util.rs
+++ b/lexical-write-float/tests/util.rs
@@ -24,8 +24,8 @@ pub fn default_proptest_config() -> ProptestConfig {
     }
 }
 
-// This is almost identical to quickcheck's itself, just to add default arguments
-//  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
+// This is almost identical to quickcheck's itself, just to add default
+// arguments  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
 // The code is unlicensed.
 #[macro_export]
 macro_rules! default_quickcheck {

--- a/lexical-write-integer/src/api.rs
+++ b/lexical-write-integer/src/api.rs
@@ -2,11 +2,12 @@
 
 #![doc(hidden)]
 
-use crate::options::Options;
-use crate::write::WriteInteger;
 use lexical_util::format::{NumberFormat, STANDARD};
 use lexical_util::num::SignedInteger;
 use lexical_util::{to_lexical, to_lexical_with_options};
+
+use crate::options::Options;
+use crate::write::WriteInteger;
 
 // UNSIGNED
 

--- a/lexical-write-integer/src/compact.rs
+++ b/lexical-write-integer/src/compact.rs
@@ -21,7 +21,8 @@ pub trait Compact: UnsignedInteger + FormattedSize {
     /// at least 128 digits as well, after subslicing the data. This guarantee
     /// is likely already made.
     fn compact(self, radix: u32, buffer: &mut [u8]) -> usize {
-        // NOTE: We do not have to validate the buffer length because `copy_to_dst` is safe.
+        // NOTE: We do not have to validate the buffer length because `copy_to_dst` is
+        // safe.
         assert!(Self::BITS <= 128);
         let mut digits: [u8; 128] = [0u8; 128];
         let mut index = digits.len();

--- a/lexical-write-integer/src/decimal.rs
+++ b/lexical-write-integer/src/decimal.rs
@@ -13,10 +13,11 @@
 #![cfg(not(feature = "compact"))]
 #![doc(hidden)]
 
-use crate::algorithm::{algorithm, algorithm_u128};
-use crate::table::DIGIT_TO_BASE10_SQUARED;
 use lexical_util::format::{RADIX, RADIX_SHIFT, STANDARD};
 use lexical_util::num::UnsignedInteger;
+
+use crate::algorithm::{algorithm, algorithm_u128};
+use crate::table::DIGIT_TO_BASE10_SQUARED;
 
 /// Fast integral log2.
 ///

--- a/lexical-write-integer/src/lib.rs
+++ b/lexical-write-integer/src/lib.rs
@@ -45,20 +45,22 @@
 //!
 //! # Safety
 //!
-//! This module uses a some more unsafe code for moderately acceptable performance. The
-//! compact decimal serializer has no non-local safety invariants, which since it's
-//! focused on code size rather than performance, this tradeoff is acceptable and it
-//! uses a temporary, over-allocated buffer as an intermediate.
+//! This module uses a some more unsafe code for moderately acceptable
+//! performance. The compact decimal serializer has no non-local safety
+//! invariants, which since it's focused on code size rather than performance,
+//! this tradeoff is acceptable and it uses a temporary, over-allocated buffer
+//! as an intermediate.
 //!
 //! The decimal writer relies on pre-computed tables and an exact calculation
 //! of the digit count ([digit_count]) to avoid any overhead. Avoid intermediary
-//! copies is **CRITICAL** for fast performance so the entire buffer must be known
-//! but assigned to use algorithms the compiler cannot easily verify. This is
-//! because we use multi-digit optimizations with our pre-computed tables,
-//! so we cannot just iterate over the slice and assign iteratively. Using checked
-//! indexing can lead to 30%+ decreases in performance. However, with careful analysis
-//! and factoring of the code, it's fairly easy to demonstrate the safety as long
-//! as the caller enusres at least the required number of digits are provided.
+//! copies is **CRITICAL** for fast performance so the entire buffer must be
+//! known but assigned to use algorithms the compiler cannot easily verify. This
+//! is because we use multi-digit optimizations with our pre-computed tables,
+//! so we cannot just iterate over the slice and assign iteratively. Using
+//! checked indexing can lead to 30%+ decreases in performance. However, with
+//! careful analysis and factoring of the code, it's fairly easy to demonstrate
+//! the safety as long as the caller enusres at least the required number of
+//! digits are provided.
 //!
 //! Our algorithms work like this, carving off the lower digits and writing them
 //! to the back of the buffer.
@@ -99,13 +101,15 @@
 //! tables are large enough so there are no non-local safety considerations
 //! there. The current logic call stack is:
 //! 1. [to_lexical]
-//! 2. [decimal][dec], compact, or radix (gts the correct tables and calls algorithm)
+//! 2. [decimal][dec], compact, or radix (gts the correct tables and calls
+//!    algorithm)
 //! 3. [algorithm]
 //!
-//! [decimal][dec], compact, and radix therefore **MUST** be safe and do type check
-//! of the bounds to avoid too much expoosure to unsafety. Only [algorithm] should
-//! have any unsafety associated with it. That is, as long as the direct caller
-//! has ensure the proper buffer is allocated, there are non-local safety invariants.
+//! [decimal][dec], compact, and radix therefore **MUST** be safe and do type
+//! check of the bounds to avoid too much expoosure to unsafety. Only
+//! [algorithm] should have any unsafety associated with it. That is, as long as
+//! the direct caller has ensure the proper buffer is allocated, there are
+//! non-local safety invariants.
 //!
 //! [digit_count]: crate::decimal::DigitCount
 //! [to_lexical]: crate::ToLexical::to_lexical
@@ -135,9 +139,10 @@ mod table_decimal;
 mod table_radix;
 
 // Re-exports
-pub use self::api::{ToLexical, ToLexicalWithOptions};
-#[doc(inline)]
-pub use self::options::{Options, OptionsBuilder};
 pub use lexical_util::constants::{FormattedSize, BUFFER_SIZE};
 pub use lexical_util::format::{self, NumberFormatBuilder};
 pub use lexical_util::options::WriteOptions;
+
+pub use self::api::{ToLexical, ToLexicalWithOptions};
+#[doc(inline)]
+pub use self::options::{Options, OptionsBuilder};

--- a/lexical-write-integer/src/radix.rs
+++ b/lexical-write-integer/src/radix.rs
@@ -12,11 +12,12 @@
 #![cfg(feature = "power-of-two")]
 #![doc(hidden)]
 
-use crate::algorithm::{algorithm, algorithm_u128};
-use crate::table::get_table;
 use lexical_util::algorithm::copy_to_dst;
 use lexical_util::format;
 use lexical_util::num::{Integer, UnsignedInteger};
+
+use crate::algorithm::{algorithm, algorithm_u128};
+use crate::table::get_table;
 
 /// Write integer to radix string.
 pub trait Radix: UnsignedInteger {
@@ -76,7 +77,8 @@ impl Radix for u128 {
     ) -> usize {
         let table = get_table::<FORMAT, MASK, SHIFT>();
         let mut digits: [u8; 128] = [0u8; 128];
-        // SAFETY: Safe since 128 bytes is always enough to hold the digits of a 128 bit integer.
+        // SAFETY: Safe since 128 bytes is always enough to hold the digits of a 128 bit
+        // integer.
         let index = unsafe { algorithm_u128::<FORMAT, MASK, SHIFT>(self, table, &mut digits) };
         copy_to_dst(buffer, &mut digits[index..])
     }

--- a/lexical-write-integer/src/table_binary.rs
+++ b/lexical-write-integer/src/table_binary.rs
@@ -5,11 +5,12 @@
 #![doc(hidden)]
 
 #[cfg(not(feature = "radix"))]
-use crate::table_decimal::*;
-#[cfg(not(feature = "radix"))]
 use lexical_util::assert::debug_assert_radix;
 #[cfg(not(feature = "radix"))]
 use lexical_util::format::radix_from_flags;
+
+#[cfg(not(feature = "radix"))]
+use crate::table_decimal::*;
 
 /// Get lookup table for 2 digit radix conversions.
 ///

--- a/lexical-write-integer/src/table_radix.rs
+++ b/lexical-write-integer/src/table_radix.rs
@@ -4,10 +4,11 @@
 #![cfg(feature = "radix")]
 #![doc(hidden)]
 
-use crate::table_binary::*;
-use crate::table_decimal::*;
 use lexical_util::assert::debug_assert_radix;
 use lexical_util::format::radix_from_flags;
+
+use crate::table_binary::*;
+use crate::table_decimal::*;
 
 /// Get lookup table for 2 digit radix conversions.
 ///

--- a/lexical-write-integer/src/write.rs
+++ b/lexical-write-integer/src/write.rs
@@ -2,6 +2,8 @@
 
 #![doc(hidden)]
 
+use lexical_util::format;
+
 /// Select the back-end.
 #[cfg(feature = "compact")]
 use crate::compact::Compact;
@@ -9,7 +11,6 @@ use crate::compact::Compact;
 use crate::decimal::Decimal;
 #[cfg(all(not(feature = "compact"), feature = "power-of-two"))]
 use crate::radix::Radix;
-use lexical_util::format;
 
 /// Define the implementation to write significant digits.
 macro_rules! write_mantissa {
@@ -68,7 +69,8 @@ pub trait WriteInteger: Compact {
     write_exponent!(Compact);
 }
 
-/// Write integer trait, implemented in terms of the optimized, decimal back-end.
+/// Write integer trait, implemented in terms of the optimized, decimal
+/// back-end.
 #[cfg(all(not(feature = "compact"), not(feature = "power-of-two")))]
 pub trait WriteInteger: Decimal {
     /// Forward write integer parameters to an optimized backend.
@@ -94,7 +96,8 @@ pub trait WriteInteger: Decimal {
     write_exponent!(Decimal);
 }
 
-/// Write integer trait, implemented in terms of the optimized, decimal or radix back-end.
+/// Write integer trait, implemented in terms of the optimized, decimal or radix
+/// back-end.
 #[cfg(all(not(feature = "compact"), feature = "power-of-two"))]
 pub trait WriteInteger: Decimal + Radix {
     /// Forward write integer parameters to an optimized backend.

--- a/lexical-write-integer/tests/api_tests.rs
+++ b/lexical-write-integer/tests/api_tests.rs
@@ -1,8 +1,8 @@
 mod util;
 
-use crate::util::default_proptest_config;
 use core::fmt::Debug;
 use core::str::{from_utf8_unchecked, FromStr};
+
 #[cfg(feature = "radix")]
 use lexical_util::constants::BUFFER_SIZE;
 #[cfg(feature = "format")]
@@ -12,6 +12,8 @@ use lexical_write_integer::{Options, ToLexical, ToLexicalWithOptions};
 use proptest::prelude::*;
 #[cfg(feature = "radix")]
 use util::from_radix;
+
+use crate::util::default_proptest_config;
 
 trait Roundtrip: ToLexical + ToLexicalWithOptions + FromStr {
     #[allow(dead_code)]

--- a/lexical-write-integer/tests/radix_tests.rs
+++ b/lexical-write-integer/tests/radix_tests.rs
@@ -3,11 +3,13 @@
 
 mod util;
 
-use crate::util::{default_proptest_config, from_radix};
 use core::str::from_utf8_unchecked;
+
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::write::WriteInteger;
 use proptest::prelude::*;
+
+use crate::util::{default_proptest_config, from_radix};
 
 #[test]
 #[cfg(feature = "radix")]

--- a/lexical-write-integer/tests/util.rs
+++ b/lexical-write-integer/tests/util.rs
@@ -31,8 +31,8 @@ pub fn default_proptest_config() -> ProptestConfig {
     }
 }
 
-// This is almost identical to quickcheck's itself, just to add default arguments
-//  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
+// This is almost identical to quickcheck's itself, just to add default
+// arguments  https://docs.rs/quickcheck/1.0.3/src/quickcheck/lib.rs.html#43-67
 // The code is unlicensed.
 #[macro_export]
 macro_rules! default_quickcheck {

--- a/lexical/src/lib.rs
+++ b/lexical/src/lib.rs
@@ -36,7 +36,6 @@
 //! ```
 //!
 //! # Conversion API
-//!
 #![cfg_attr(feature = "write", doc = " **To String**")]
 #![cfg_attr(feature = "write", doc = "")]
 #![cfg_attr(feature = "write", doc = " - [`to_string`]")]
@@ -52,8 +51,8 @@
 //! # Features
 //!
 //! In accordance with the Rust ethos, all features are additive: the crate
-//! may be build with `--all-features` without issue.  The following features are enabled
-//! by default:
+//! may be build with `--all-features` without issue.  The following features
+//! are enabled by default:
 //!
 //! * `std`
 //! * `write-integers`
@@ -156,7 +155,7 @@
 //!
 //! Lexical provides two main levels of configuration:
 //! - The [`NumberFormatBuilder`], creating a packed struct with custom
-//!     formatting options.
+//!   formatting options.
 //! - The Options API.
 //!
 //! ## Number Format
@@ -171,8 +170,10 @@
 //! When the `format` feature is enabled, numerous other syntax and
 //! digit separator flags are enabled, including:
 //! - A digit separator character, to group digits for increased legibility.
-//! - Whether leading, trailing, internal, and consecutive digit separators are allowed.
-//! - Toggling required float components, such as digits before the decimal point.
+//! - Whether leading, trailing, internal, and consecutive digit separators are
+//!   allowed.
+//! - Toggling required float components, such as digits before the decimal
+//!   point.
 //! - Toggling whether special floats are allowed or are case-sensitive.
 //!
 //! Many pre-defined constants therefore exist to simplify common use-cases,
@@ -194,7 +195,6 @@
 //! - The rounding mode when truncating significant digits while writing.
 //!
 //! The available options are:
-//!
 #![cfg_attr(feature = "parse-floats", doc = " - [`ParseFloatOptions`]")]
 #![cfg_attr(feature = "parse-integers", doc = " - [`ParseIntegerOptions`]")]
 #![cfg_attr(feature = "write-floats", doc = " - [`WriteFloatOptions`]")]
@@ -310,14 +310,14 @@ pub use lexical_core::{FromLexical, FromLexicalWithOptions};
 #[cfg(feature = "write")]
 pub use lexical_core::{ToLexical, ToLexicalWithOptions};
 
-// NOTE: We cannot just use an uninitialized vector with excess capacity and then use
-// read-assign rather than `ptr::write` or `MaybeUninit.write` to modify the values.
-// When LLVM was the primary codegen, this was **UNSPECIFIED** but not undefined
-// behavior: reading undef primitives is safe:
+// NOTE: We cannot just use an uninitialized vector with excess capacity and
+// then use read-assign rather than `ptr::write` or `MaybeUninit.write` to
+// modify the values. When LLVM was the primary codegen, this was
+// **UNSPECIFIED** but not undefined behavior: reading undef primitives is safe:
 //  https://llvm.org/docs/LangRef.html#undefined-values
 //
-// However, a different backend such as cranelift might make this undefined behavior.
-// That is, from the perspective of Rust, this is UB:
+// However, a different backend such as cranelift might make this undefined
+// behavior. That is, from the perspective of Rust, this is UB:
 //
 //  ```rust
 //  let x = Vec::<u8>::with_capacity(500);
@@ -330,9 +330,9 @@ pub use lexical_core::{ToLexical, ToLexicalWithOptions};
 //  ptr.write(1);
 //  ```
 //
-// Currently, since LLVM treats it as unspecified behavior and will not drop values,
-// there is no risk of a memory leak and this is **currently** safe. However, this
-// can explode at any time, just like any UB.
+// Currently, since LLVM treats it as unspecified behavior and will not drop
+// values, there is no risk of a memory leak and this is **currently** safe.
+// However, this can explode at any time, just like any UB.
 
 /// High-level conversion of a number to a decimal-encoded string.
 ///
@@ -355,7 +355,8 @@ pub fn to_string<N: ToLexical>(n: N) -> String {
     let mut buf = vec![0u8; N::FORMATTED_SIZE_DECIMAL];
     let len = lexical_core::write(n, buf.as_mut_slice()).len();
 
-    // SAFETY: safe since the buffer is of sufficient size, len() must be <= the vec size.
+    // SAFETY: safe since the buffer is of sufficient size, len() must be <= the vec
+    // size.
     unsafe {
         buf.set_len(len);
         String::from_utf8_unchecked(buf)
@@ -387,13 +388,15 @@ pub fn to_string_with_options<N: ToLexicalWithOptions, const FORMAT: u128>(
     n: N,
     options: &N::Options,
 ) -> String {
-    // Need to use the buffer_size hint to properly deal with float formatting options.
+    // Need to use the buffer_size hint to properly deal with float formatting
+    // options.
     let size = N::Options::buffer_size::<N, FORMAT>(options);
     let mut buf = vec![0u8; size];
     let slc = buf.as_mut_slice();
     let len = lexical_core::write_with_options::<_, FORMAT>(n, slc, options).len();
 
-    // SAFETY: safe since the buffer is of sufficient size, len() must be <= the vec size.
+    // SAFETY: safe since the buffer is of sufficient size, len() must be <= the vec
+    // size.
     unsafe {
         buf.set_len(len);
         String::from_utf8_unchecked(buf)
@@ -519,7 +522,8 @@ pub fn parse_with_options<N: FromLexicalWithOptions, Bytes: AsRef<[u8]>, const F
     N::from_lexical_with_options::<FORMAT>(bytes.as_ref(), options)
 }
 
-/// High-level, partial conversion of bytes to a number with custom parsing options.
+/// High-level, partial conversion of bytes to a number with custom parsing
+/// options.
 ///
 /// This functions parses as many digits as possible, returning the parsed
 /// value and the number of digits processed if at least one character

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -14,3 +14,6 @@ imports_indent = "Block"
 imports_layout = "HorizontalVertical"
 indent_style = "Block"
 match_arm_blocks = true
+overflow_delimited_expr = true
+group_imports = "StdExternalCrate"
+wrap_comments = true


### PR DESCRIPTION
Minor changes with compile-time code elimination via `#[cfg(...)]` rather than trusting the compiler to do dead-code elimination via `if cfg!(...)` to get major performance improvements, seemingly getting 10% to 20% better performance for fast case scenarios.