### PR TITLE
Update documentation and make method names more expressive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Lexical is highly customizable, and contains numerous other optional features:
 - **f16**: &ensp; Add support for numeric conversions to-and-from 16-bit floats.
     <blockquote>Adds <code>f16</code>, a half-precision IEEE-754 floating-point type, and <code>bf16</code>, the Brain Float 16 type, and numeric conversions to-and-from these floats. Note that since these are storage formats, and therefore do not have native arithmetic operations, all conversions are done using an intermediate <code>f32</code>.</blockquote>
 
-To ensure the safety when bounds checking is disabled, we extensively fuzz the all numeric conversion routines. See the [Safety](#safety) section below for more information.
+To ensure memory safety, we extensively fuzz the all numeric conversion routines. See the [Safety](#safety) section below for more information.
 
 Lexical also places a heavy focus on code bloat: with algorithms both optimized for performance and size. By default, this focuses on performance, however, using the `compact` feature, you can also opt-in to reduced code size at the cost of performance. The compact algorithms minimize the use of pre-computed tables and other optimizations at a major cost to performance.
 
@@ -304,9 +304,7 @@ A benchmark on writing floats generated via a random-number generator and parsed
 
 ## Safety
 
-Due to the use of memory unsafe code in the integer and float writers, we extensively fuzz our float writers and parsers. The fuzz harnesses may be found under [fuzz](https://github.com/Alexhuszagh/rust-lexical/tree/main/fuzz), and are run continuously. So far, we've parsed and written over 72 billion floats.
-
-Due to the simple logic of the integer writers, and the lack of memory safety in the integer parsers, we minimally fuzz both, and test it with edge-cases, which has shown no memory safety issues to date.
+Due to the use of memory unsafe code in the library, we extensively fuzz our float writers and parsers. The fuzz harnesses may be found under [fuzz](https://github.com/Alexhuszagh/rust-lexical/tree/main/fuzz), and are run continuously. So far, we've parsed and written over 72 billion floats.
 
 ## Platform Support
 

--- a/lexical-parse-float/src/bigint.rs
+++ b/lexical-parse-float/src/bigint.rs
@@ -586,8 +586,7 @@ impl<const SIZE: usize> StackVec<SIZE> {
     pub fn from_u16(x: u16) -> Self {
         let mut vec = Self::new();
         assert!(1 <= vec.capacity());
-        // SAFETY: safe since we can always add 1 item.
-        unsafe { vec.push_unchecked(x as Limb) };
+        _ = vec.try_push(x as Limb);
         vec.normalize();
         vec
     }
@@ -598,8 +597,7 @@ impl<const SIZE: usize> StackVec<SIZE> {
         let mut vec = Self::new();
         debug_assert!(1 <= vec.capacity());
         assert!(1 <= SIZE);
-        // SAFETY: safe since we can always add 1 item (validated in the asset).
-        unsafe { vec.push_unchecked(x as Limb) };
+        _ = vec.try_push(x as Limb);
         vec.normalize();
         vec
     }
@@ -611,14 +609,10 @@ impl<const SIZE: usize> StackVec<SIZE> {
         debug_assert!(2 <= vec.capacity());
         assert!(2 <= SIZE);
         if LIMB_BITS == 32 {
-            // SAFETY: safe since we can always add 2 items (validated in the asset).
-            unsafe {
-                vec.push_unchecked(x as Limb);
-                vec.push_unchecked((x >> 32) as Limb);
-            }
+            _ = vec.try_push(x as Limb);
+            _ = vec.try_push((x >> 32) as Limb);
         } else {
-            // SAFETY: safe since we can always add 1 item.
-            unsafe { vec.push_unchecked(x as Limb) };
+            _ = vec.try_push(x as Limb);
         }
         vec.normalize();
         vec

--- a/lexical-parse-float/src/slow.rs
+++ b/lexical-parse-float/src/slow.rs
@@ -685,7 +685,7 @@ pub fn compare_bytes<const FORMAT: u128>(
     let mut integer = number.integer.bytes::<{ FORMAT }>();
     let mut integer_iter = integer.integer_iter();
     integer_iter.skip_zeros();
-    if integer_iter.is_done() {
+    if integer_iter.is_buffer_empty() {
         // Cannot be empty, since we must have at least **some** significant digits.
         let mut fraction = number.fraction.unwrap().bytes::<{ FORMAT }>();
         let mut fraction_iter = fraction.fraction_iter();

--- a/lexical-util/src/lib.rs
+++ b/lexical-util/src/lib.rs
@@ -55,7 +55,7 @@
 //! correctly.
 //!
 //! To see if the cursor is at the end of the buffer, use
-//! [DigitsIter::is_done][is_done].
+//! [is_buffer_empty][crate::iterator::Iter::is_buffer_empty].
 //!
 //! Any iterators must be peekable: you must be able to read and return the next
 //! value without advancing the iterator past that point. For iterators that
@@ -66,7 +66,7 @@
 //! like:
 //!
 //! ```rust,ignore
-//! unsafe impl<_> DigitsIter<_> for MyIter {
+//! impl<_> DigitsIter<_> for MyIter {
 //!     fn peek(&mut self) -> Option<u8> {
 //!         loop {
 //!             let value = self.bytes.get(self.index)?;
@@ -95,7 +95,7 @@
 //! }
 //! ```
 //!
-//! [is_done]: iterator::DigitsIter::is_done
+//! [is_buffer_empty]: iterator::Iter::is_buffer_empty
 //! [is_consumed]: iterator::DigitsIter::is_consumed
 //! [peek]: iterator::DigitsIter::peek
 

--- a/lexical-util/src/noskip.rs
+++ b/lexical-util/src/noskip.rs
@@ -49,10 +49,10 @@ impl<'a, const __: u128> Bytes<'a, __> {
         }
     }
 
-    // TODO: Move to `Iter` as a trait along with `new` as well`
     /// Initialize the slice from raw parts.
     ///
     /// # Safety
+    ///
     /// This is safe if and only if the index is <= slc.len().
     /// For this reason, since it's easy to get wrong, we only
     /// expose it to `DigitsIterator` and nothing else.
@@ -65,13 +65,6 @@ impl<'a, const __: u128> Bytes<'a, __> {
             slc,
             index,
         }
-    }
-
-    /// Get if the buffer underlying the iterator is empty.
-    /// Same as `is_consumed`.
-    #[inline(always)]
-    pub fn is_done(&self) -> bool {
-        self.index >= self.slc.len()
     }
 
     /// Get iterator over integer digits.
@@ -107,7 +100,7 @@ impl<'a, const __: u128> Bytes<'a, __> {
     }
 }
 
-unsafe impl<'a, const __: u128> Iter<'a> for Bytes<'a, __> {
+impl<'a, const __: u128> Iter<'a> for Bytes<'a, __> {
     const IS_CONTIGUOUS: bool = true;
 
     #[inline(always)]
@@ -136,12 +129,6 @@ unsafe impl<'a, const __: u128> Iter<'a> for Bytes<'a, __> {
     #[inline(always)]
     fn current_count(&self) -> usize {
         self.index
-    }
-
-    // TODO: Rename
-    #[inline(always)]
-    fn is_empty(&self) -> bool {
-        self.as_slice().is_empty()
     }
 
     #[inline(always)]
@@ -212,7 +199,7 @@ impl<'a: 'b, 'b, const __: u128> DigitsIterator<'a, 'b, __> {
     }
 }
 
-unsafe impl<'a: 'b, 'b, const __: u128> Iter<'a> for DigitsIterator<'a, 'b, __> {
+impl<'a: 'b, 'b, const __: u128> Iter<'a> for DigitsIterator<'a, 'b, __> {
     const IS_CONTIGUOUS: bool = Bytes::<'a, __>::IS_CONTIGUOUS;
 
     #[inline(always)]
@@ -238,16 +225,6 @@ unsafe impl<'a: 'b, 'b, const __: u128> Iter<'a> for DigitsIterator<'a, 'b, __> 
     }
 
     #[inline(always)]
-    fn is_empty(&self) -> bool {
-        self.byte.is_done()
-    }
-
-    #[inline(always)]
-    fn first(&self) -> Option<&'a u8> {
-        self.byte.first()
-    }
-
-    #[inline(always)]
     unsafe fn step_by_unchecked(&mut self, count: usize) {
         debug_assert!(self.as_slice().len() >= count);
         // SAFETY: safe as long as `slc.len() >= count`.
@@ -265,12 +242,7 @@ unsafe impl<'a: 'b, 'b, const __: u128> Iter<'a> for DigitsIterator<'a, 'b, __> 
 impl<'a: 'b, 'b, const FORMAT: u128> DigitsIter<'a> for DigitsIterator<'a, 'b, FORMAT> {
     #[inline(always)]
     fn is_consumed(&mut self) -> bool {
-        Self::is_done(self)
-    }
-
-    #[inline(always)]
-    fn is_done(&self) -> bool {
-        self.byte.is_done()
+        self.is_buffer_empty()
     }
 
     #[inline(always)]

--- a/lexical-util/tests/iterator_tests.rs
+++ b/lexical-util/tests/iterator_tests.rs
@@ -20,7 +20,7 @@ fn digits_iterator_test() {
     assert_eq!(iter.as_slice(), &digits[..]);
     assert_eq!(iter.as_ptr(), digits.as_ptr());
     assert_eq!(iter.is_consumed(), false);
-    assert_eq!(iter.is_done(), false);
+    assert_eq!(iter.is_buffer_empty(), false);
     assert_eq!(u32::from_le(iter.peek_u32().unwrap()), 0x34333231);
     assert_eq!(iter.buffer_length(), 5);
     assert_eq!(iter.cursor(), 0);
@@ -83,7 +83,7 @@ fn skip_iterator_test() {
     assert_eq!(iter.as_slice(), &digits[..]);
     assert_eq!(iter.as_ptr(), digits.as_ptr());
     assert_eq!(iter.is_consumed(), false);
-    assert_eq!(iter.is_done(), false);
+    assert_eq!(iter.is_buffer_empty(), false);
     assert_eq!(iter.buffer_length(), 6);
     assert_eq!(iter.cursor(), 0);
     assert_eq!(iter.current_count(), 0);

--- a/lexical-write-float/src/write.rs
+++ b/lexical-write-float/src/write.rs
@@ -70,19 +70,10 @@ where
 
 /// Write float trait.
 pub trait WriteFloat: RawFloat + FormattedSize {
-    /// Forward write integer parameters to an unoptimized backend.
+    /// Forward float writing parameters and write the float.
     ///
-    /// # Safety
-    ///
-    /// # TODO: This is now safe effectively
-    /// Safe as long as the buffer can hold [`FORMATTED_SIZE`] elements
-    /// (or [`FORMATTED_SIZE_DECIMAL`] for decimal). If using custom digit
-    /// precision control (such as specifying a minimum number of significant
-    /// digits), or disabling scientific notation, then more digits may be
-    /// required (up to `1075` for the leading or trailing zeros, `1` for
-    /// the sign and `1` for the decimal point). So,
-    /// `1077 + min_significant_digits.max(52)`, so ~1200 for a reasonable
-    /// threshold.
+    /// This abstracts away handling different optimizations and radices into
+    /// a single API.
     ///
     /// # Panics
     ///

--- a/lexical/src/lib.rs
+++ b/lexical/src/lib.rs
@@ -350,8 +350,6 @@ pub use lexical_core::{ToLexical, ToLexicalWithOptions};
 #[inline]
 #[cfg(feature = "write")]
 pub fn to_string<N: ToLexical>(n: N) -> String {
-    // TODO: Change to use our `MaybeUnint` API and a `with_capacity` to
-    // avoid the overhead of the calloc here.
     let mut buf = vec![0u8; N::FORMATTED_SIZE_DECIMAL];
     let len = lexical_core::write(n, buf.as_mut_slice()).len();
 


### PR DESCRIPTION
This ensures any ambiguity from the method names would not cause potential issues among maintainers. There's 2 abstractions that contain 193/250 of the unsafe expressions and everything is clearly documented and the safety requirements are clearly documented and effectively every call of these unsafe methods is made within the trait/struct.

For example, in `Bigint`, the majority of the "unsafety" are methods like `push_unchecked`, `pop_unchecked`, and `extend_unchecked`, which are only called by `try_push`, `pop`, and `try_extend`, respectively. The same logic extends for essentially the entire implementation.

Closes #100 
Closes #138 