### PR TITLE
Make inlining consistent between API methods.

### DIFF
--- a/lexical-parse-integer/src/api.rs
+++ b/lexical-parse-integer/src/api.rs
@@ -15,16 +15,14 @@ use crate::parse::ParseInteger;
 /// can actually be evaluated at compile-time, which causes major branching
 /// issues.
 macro_rules! integer_from_lexical {
-    ($($t:ident $unsigned:ident $(, #[$meta:meta])? ; )*) => ($(
+    ($($t:ident $unsigned:ident ; )*) => ($(
         impl FromLexical for $t {
-            $(#[$meta:meta])?
             #[cfg_attr(not(feature = "compact"), inline)]
             fn from_lexical(bytes: &[u8]) -> lexical_util::result::Result<Self>
             {
                 Self::parse_complete::<STANDARD>(bytes, &DEFAULT_OPTIONS)
             }
 
-            $(#[$meta:meta])?
             #[cfg_attr(not(feature = "compact"), inline)]
             fn from_lexical_partial(
                 bytes: &[u8],
@@ -37,7 +35,6 @@ macro_rules! integer_from_lexical {
         impl FromLexicalWithOptions for $t {
             type Options = Options;
 
-            $(#[$meta:meta])?
             #[cfg_attr(not(feature = "compact"), inline)]
             fn from_lexical_with_options<const FORMAT: u128>(
                 bytes: &[u8],
@@ -51,7 +48,6 @@ macro_rules! integer_from_lexical {
                 Self::parse_complete::<FORMAT>(bytes, options)
             }
 
-            $(#[$meta:meta])?
             #[cfg_attr(not(feature = "compact"), inline)]
             fn from_lexical_partial_with_options<const FORMAT: u128>(
                 bytes: &[u8],

--- a/lexical-write-float/src/api.rs
+++ b/lexical-write-float/src/api.rs
@@ -18,9 +18,9 @@ const DEFAULT_OPTIONS: Options = Options::new();
 
 // Implement ToLexical for numeric type.
 macro_rules! float_to_lexical {
-    ($($t:tt $(, #[$meta:meta])? ; )*) => ($(
+    ($($t:tt ; )*) => ($(
         impl ToLexical for $t {
-            $(#[$meta:meta])?
+            #[cfg_attr(not(feature = "compact"), inline)]
             fn to_lexical(self, bytes: &mut [u8])
                 -> &mut [u8]
             {
@@ -31,7 +31,7 @@ macro_rules! float_to_lexical {
 
         impl ToLexicalWithOptions for $t {
             type Options = Options;
-            $(#[$meta:meta])?
+            #[cfg_attr(not(feature = "compact"), inline)]
             fn to_lexical_with_options<'a, const FORMAT: u128>(
                 self,
                 bytes: &'a mut [u8],

--- a/lexical-write-integer/src/api.rs
+++ b/lexical-write-integer/src/api.rs
@@ -74,9 +74,9 @@ where
 
 // Implement ToLexical for numeric type.
 macro_rules! unsigned_to_lexical {
-    ($($narrow:tt $wide:tt $(, #[$meta:meta])? ; )*) => ($(
+    ($($narrow:tt $wide:tt ; )*) => ($(
         impl ToLexical for $narrow {
-            $(#[$meta:meta])?
+            #[cfg_attr(not(feature = "compact"), inline)]
             fn to_lexical(self, bytes: &mut [u8])
                 -> &mut [u8]
             {
@@ -88,7 +88,7 @@ macro_rules! unsigned_to_lexical {
         impl ToLexicalWithOptions for $narrow {
             type Options = Options;
 
-            $(#[$meta:meta])?
+            #[cfg_attr(not(feature = "compact"), inline)]
             fn to_lexical_with_options<'a, const FORMAT: u128>(
                 self,
                 bytes: &'a mut [u8],
@@ -122,11 +122,9 @@ unsigned_to_lexical! { usize u64 ; }
 
 // Implement ToLexical for numeric type.
 macro_rules! signed_to_lexical {
-    ($($narrow:tt $wide:tt $unsigned:tt $(, #[$meta:meta])? ; )*) => ($(
+    ($($narrow:tt $wide:tt $unsigned:tt ; )*) => ($(
         impl ToLexical for $narrow {
-            $(#[$meta:meta])?
-            $(#[$meta:meta])?
-            #[inline]
+            #[cfg_attr(not(feature = "compact"), inline)]
             fn to_lexical(self, bytes: &mut [u8])
                 -> &mut [u8]
             {
@@ -137,8 +135,7 @@ macro_rules! signed_to_lexical {
 
         impl ToLexicalWithOptions for $narrow {
             type Options = Options;
-            $(#[$meta:meta])?
-            #[inline]
+            #[cfg_attr(not(feature = "compact"), inline)]
             fn to_lexical_with_options<'a, const FORMAT: u128>(
                 self,
                 bytes: &'a mut [u8],


### PR DESCRIPTION
Closes #145.