### PR TITLE
Patch issue with incorrect parsing of leading zeros.

### DIFF
--- a/lexical-parse-float/tests/issue_98_tests.rs
+++ b/lexical-parse-float/tests/issue_98_tests.rs
@@ -1,0 +1,67 @@
+#![cfg(all(feature = "power-of-two", feature = "format"))]
+
+use std::assert_eq;
+
+use lexical_parse_float::FromLexicalWithOptions;
+use lexical_parse_float::NumberFormatBuilder;
+use lexical_parse_float::Options;
+use lexical_util::error::Error;
+
+#[test]
+fn issue_98_test() {
+    const DECIMAL_FORMAT: u128 = NumberFormatBuilder::new()
+        .required_digits(true)
+        .no_positive_mantissa_sign(false)
+        .no_special(true)
+        .no_integer_leading_zeros(true)
+        .no_float_leading_zeros(true)
+        .build();
+    let result = f64::from_lexical_with_options::<DECIMAL_FORMAT>(b"1.1.0", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidDigit(3));
+    assert_eq!(
+        f64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"1.1.0", &Options::new()),
+        Ok((1.1f64, 3))
+    );
+    assert_eq!(
+        f64::from_lexical_with_options::<DECIMAL_FORMAT>(b"1.1", &Options::new()),
+        Ok(1.1f64)
+    );
+    assert_eq!(
+        f64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"1.1", &Options::new()),
+        Ok((1.1f64, 3))
+    );
+
+    let result = f64::from_lexical_with_options::<DECIMAL_FORMAT>(b"0.1.0", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidDigit(3));
+    assert_eq!(
+        f64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"0.1.0", &Options::new()),
+        Ok((0.1f64, 3))
+    );
+    assert_eq!(
+        f64::from_lexical_with_options::<DECIMAL_FORMAT>(b"0.1", &Options::new()),
+        Ok(0.1f64)
+    );
+    assert_eq!(
+        f64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"0.1", &Options::new()),
+        Ok((0.1f64, 3))
+    );
+
+    let result = f64::from_lexical_with_options::<DECIMAL_FORMAT>(b"01.1.0", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidLeadingZeros(0));
+
+    let result = f64::from_lexical_with_options::<DECIMAL_FORMAT>(b"00.1", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidLeadingZeros(0));
+
+    assert_eq!(
+        f64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"10.1", &Options::new()),
+        Ok((10.1, 4))
+    );
+    assert_eq!(
+        f64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"11.1", &Options::new()),
+        Ok((11.1, 4))
+    );
+}

--- a/lexical-parse-integer/tests/issue_98_tests.rs
+++ b/lexical-parse-integer/tests/issue_98_tests.rs
@@ -1,0 +1,67 @@
+#![cfg(all(feature = "power-of-two", feature = "format"))]
+
+use lexical_parse_integer::FromLexicalWithOptions;
+use lexical_parse_integer::NumberFormatBuilder;
+use lexical_parse_integer::Options;
+use lexical_util::error::Error;
+
+#[test]
+fn issue_98_test() {
+    const DECIMAL_FORMAT: u128 = NumberFormatBuilder::new()
+        .required_digits(true)
+        .no_positive_mantissa_sign(false)
+        .no_special(true)
+        .no_integer_leading_zeros(true)
+        .no_float_leading_zeros(false)
+        .build();
+    let result = i64::from_lexical_with_options::<DECIMAL_FORMAT>(b"1.1.0", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidDigit(1));
+    assert_eq!(
+        i64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"1.1.0", &Options::new()),
+        Ok((1, 1))
+    );
+
+    let result = i64::from_lexical_with_options::<DECIMAL_FORMAT>(b"1.1", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidDigit(1));
+    assert!(i64::from_lexical_with_options::<DECIMAL_FORMAT>(b"1.1", &Options::new()).is_err());
+    assert_eq!(
+        i64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"1.1", &Options::new()),
+        Ok((1, 1))
+    );
+
+    let result = i64::from_lexical_with_options::<DECIMAL_FORMAT>(b"0.1.0", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidDigit(1));
+    assert_eq!(
+        i64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"0.1.0", &Options::new()),
+        Ok((0, 1))
+    );
+
+    let result = i64::from_lexical_with_options::<DECIMAL_FORMAT>(b"0.1", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidDigit(1));
+    assert!(i64::from_lexical_with_options::<DECIMAL_FORMAT>(b"0.1", &Options::new()).is_err());
+    assert_eq!(
+        i64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"0.1", &Options::new()),
+        Ok((0, 1))
+    );
+
+    let result = i64::from_lexical_with_options::<DECIMAL_FORMAT>(b"01.1", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidLeadingZeros(0));
+
+    let result = i64::from_lexical_with_options::<DECIMAL_FORMAT>(b"00.1", &Options::new());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Error::InvalidLeadingZeros(0));
+
+    assert_eq!(
+        i64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"10.1", &Options::new()),
+        Ok((10, 2))
+    );
+    assert_eq!(
+        i64::from_lexical_partial_with_options::<DECIMAL_FORMAT>(b"11.1", &Options::new()),
+        Ok((11, 2))
+    );
+}


### PR DESCRIPTION
This affects integers where they have a leading 0 followed by a non-digit character when the format API is enabled and for non-partial parsers. This should return an error. Tests have been introduced to avoid regressions.

Closes #98