### PR TITLE
Ensure leading invalid digits for floats correctly error.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Inlining inconsistency between public API methods (credit to @zheland)
+- Incorrectly accepting leading zeros when `no_integer_leading_zeros` was enabled.
+- Have consistent errors when an invalid leading digit is found for floating point numbers to always be `Error::InvalidDigit`.
 
 ## [1.0.1] 2024-09-16
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@ A benchmarks for values with a large integers.
 
 ![Simple Int64](https://github.com/Alexhuszagh/lexical-benchmarks/raw/main/results/da4728e/plot/random_simple_int64%20-%20write%20float%20-%20dtoa,fmt,lexical,ryu.png)
 
-
 **Random**
 
 ![Random](https://github.com/Alexhuszagh/lexical-benchmarks/raw/main/results/da4728e/plot/json%20-%20write%20float%20-%20dtoa,fmt,lexical,ryu.png)

--- a/lexical-core/tests/issue_97_tests.rs
+++ b/lexical-core/tests/issue_97_tests.rs
@@ -1,0 +1,62 @@
+#![cfg(all(feature = "parse", feature = "format"))]
+
+use core::num;
+
+use lexical_core::{Error, FromLexical, FromLexicalWithOptions, NumberFormatBuilder};
+
+#[test]
+fn issue_97_test() {
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .internal_digit_separator(true)
+        .build();
+
+    let fopts = lexical_core::ParseFloatOptions::new();
+    let iopts = lexical_core::ParseIntegerOptions::new();
+
+    assert_eq!(
+        i64::from_lexical_with_options::<FMT>(b"_1234", &iopts),
+        Err(Error::InvalidDigit(0))
+    );
+    assert_eq!(
+        i64::from_lexical_with_options::<FMT>(b"1234_", &iopts),
+        Err(Error::InvalidDigit(4))
+    );
+
+    assert_eq!(
+        f64::from_lexical_with_options::<FMT>(b"_1234", &fopts),
+        Err(Error::InvalidDigit(0))
+    );
+    assert_eq!(
+        f64::from_lexical_with_options::<FMT>(b"1234_", &fopts),
+        Err(Error::InvalidDigit(4))
+    );
+
+    assert_eq!(
+        f64::from_lexical_with_options::<FMT>(b"_12.34", &fopts),
+        Err(Error::InvalidDigit(0))
+    );
+    assert_eq!(
+        f64::from_lexical_with_options::<FMT>(b"12.34_", &fopts),
+        Err(Error::InvalidDigit(5))
+    );
+
+    assert_eq!(f64::from_lexical_with_options::<FMT>(b"1_2.34", &fopts), Ok(12.34));
+}
+
+#[test]
+fn issue_97_nofmt_test() {
+    assert_eq!(i64::from_lexical(b"_1234"), Err(Error::InvalidDigit(0)));
+    assert_eq!(i64::from_lexical(b"1234_"), Err(Error::InvalidDigit(4)));
+
+    assert_eq!(f64::from_lexical(b"_1234"), Err(Error::InvalidDigit(0)));
+    assert_eq!(f64::from_lexical(b"1234_"), Err(Error::InvalidDigit(4)));
+
+    assert_eq!(f64::from_lexical(b"_12.34"), Err(Error::InvalidDigit(0)));
+    assert_eq!(f64::from_lexical(b"12.34_"), Err(Error::InvalidDigit(5)));
+
+    assert_eq!(f64::from_lexical(b"_.34"), Err(Error::InvalidDigit(0)));
+    assert_eq!(f64::from_lexical(b"0_0.34"), Err(Error::InvalidDigit(1)));
+
+    assert_eq!(f64::from_lexical(b".34"), Ok(0.34));
+}


### PR DESCRIPTION
This corrects the behavior from reporting an EmptyMantissa to correctly report an InvalidDigit.

Closes #97