### PR TITLE
Fixes the `is_contiguous` check on digits iterators.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A correctness regression.
+- Regressions where parsing digit separators without the `compact` panicked.
 
 ## [1.0.0] 2024-09-14
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -80,6 +80,8 @@ test() {
     cargo test $test_features $DOCTESTS
     cargo test $test_features $DOCTESTS --release
     cargo test --features=radix,format,compact $DOCTESTS --release
+    # NOTE: This tests a regressions, related to #96.
+    cargo test --features=format $DOCTESTS
 }
 
 # Dry-run bench target


### PR DESCRIPTION
This no longer does the check on the byte which is the correct check.

Fixes #157