### PR TITLE
Disallow I/O methods via clippy.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,18 @@
 avoid-breaking-exported-api = false
+disallowed-macros = [
+    # Can also use an inline table with a `path` key.
+    { path = "std::print", reason = "no IO allowed" },
+    { path = "std::println", reason = "no IO allowed" },
+    { path = "std::format", reason = "no string allocation allowed" },
+    { path = "std::debug", reason = "debugging macros should not be present in any release" },
+]
+disallowed-methods = [
+    { path = "std::io::stdout", reason = "no IO allowed" },
+    { path = "std::io::stdin", reason = "no IO allowed" },
+    { path = "std::io::stderr", reason = "no IO allowed" },
+]
+disallowed-types = [
+    { path = "std::io::File", reason = "no IO allowed" },
+    { path = "std::io::BufReader", reason = "need our own abstractions for reading/writing" },
+    { path = "std::io::BufWriter", reason = "need our own abstractions for reading/writing" },
+]

--- a/lexical-asm/clippy.toml
+++ b/lexical-asm/clippy.toml
@@ -1,1 +1,1 @@
-../clippy.toml
+avoid-breaking-exported-api = false

--- a/lexical-benchmark/clippy.toml
+++ b/lexical-benchmark/clippy.toml
@@ -1,1 +1,1 @@
-../clippy.toml
+avoid-breaking-exported-api = false

--- a/lexical-size/clippy.toml
+++ b/lexical-size/clippy.toml
@@ -1,1 +1,1 @@
-../clippy.toml
+avoid-breaking-exported-api = false


### PR DESCRIPTION
Use clippy lints to disallow macros like `println!`, etc., and other diagnostic macros and/or tools, or those that use general I/O.

Closes #159.