### PR TITLE
Improve the formatting API.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Higher performance when parsing floats with digit separators.
+
 ### Fixed
 
 - Inlining inconsistency between public API methods (credit to @zheland)
 - Incorrectly accepting leading zeros when `no_integer_leading_zeros` was enabled.
 - Have consistent errors when an invalid leading digit is found for floating point numbers to always be `Error::InvalidDigit`.
+- Incorrect parsing of consecutive digit separators.
+- Inaccuracies when parsing digit separators at various positions leading to incorect errors being returned.
 
 ## [1.0.1] 2024-09-16
 

--- a/ci/comprehensive.sh
+++ b/ci/comprehensive.sh
@@ -18,6 +18,7 @@ run_tests() {
     cd "${home}"
     cd lexical-parse-float/etc/correctness
     cargo run "${@}" --release --bin test-parse-golang
+    cargo run "${@}" --release --bin test-parse-golang --features digit-separator
     cargo run "${@}" --release --bin test-parse-unittests
 
     # Test the write-float correctness tests.

--- a/clippy.toml
+++ b/clippy.toml
@@ -5,6 +5,8 @@ disallowed-macros = [
     { path = "std::println", reason = "no IO allowed" },
     { path = "std::format", reason = "no string allocation allowed" },
     { path = "std::debug", reason = "debugging macros should not be present in any release" },
+    # NOTE: unimplemented is fine because this can be for intentionally disabled methods
+    { path = "std::todo", reason = "should never have TODO macros in releases" },
 ]
 disallowed-methods = [
     { path = "std::io::stdout", reason = "no IO allowed" },

--- a/lexical-parse-float/etc/correctness/Cargo.toml
+++ b/lexical-parse-float/etc/correctness/Cargo.toml
@@ -10,19 +10,27 @@ path = "../.."
 default-features = false
 features = []
 
+[dependencies.lexical-util]
+path = "../../../lexical-util"
+default-features = false
+features = []
+
 [dependencies]
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
 rand_isaac = ">=0.3.0"
+regex = { version = ">=1.10.6", optional = true}
+lazy_static = { version = ">=1.5.0", optional = true }
 
 [features]
-std = ["lexical-parse-float/std"]
-power-of-two = ["lexical-parse-float/power-of-two"]
-radix = ["lexical-parse-float/radix"]
-format = ["lexical-parse-float/format"]
+std = ["lexical-parse-float/std", "lexical-util/std"]
+power-of-two = ["lexical-parse-float/power-of-two", "lexical-util/power-of-two"]
+radix = ["lexical-parse-float/radix", "lexical-util/radix"]
+format = ["lexical-parse-float/format", "lexical-util/format"]
 compact = ["lexical-parse-float/compact"]
+digit-separator = ["format", "regex", "lazy_static"]
 
 [workspace]
 

--- a/lexical-parse-float/etc/correctness/test-parse-golang/main.rs
+++ b/lexical-parse-float/etc/correctness/test-parse-golang/main.rs
@@ -1,10 +1,36 @@
 // Copyright 2021, Alex Huszagh. Unlicensed.
 // See https://unlicense.org/
 
-use lexical_parse_float::FromLexical;
+#![allow(unused_imports)]
+
+use lexical_parse_float::{FromLexicalWithOptions, Options};
+use lexical_util::format::{NumberFormatBuilder, STANDARD};
+use rand::{Rng, SeedableRng};
+use rand_isaac::Isaac64Rng;
+use core::{num, str};
 use std::collections::HashMap;
 
-fn run_test(line: &str) {
+#[allow(dead_code)]
+pub const ISAAC_SEED: [u8; 32] = [
+    49, 52, 49, 53, 57, 50, 54, 53, 51, 53, 56, 57, 55, 57, 51, 50, 51, 56, 52, 54, 50, 54, 52, 51,
+    51, 56, 51, 50, 55, 57, 53, 48,
+];
+
+#[cfg(feature = "digit-separator")]
+lazy_static::lazy_static! {
+    static ref SIGN: regex::Regex = regex::Regex::new("(_+)([+-])").unwrap();
+}
+
+#[cfg(feature = "digit-separator")]
+fn run_test<Random: Rng>(line: &str, rng: &mut Random) {
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(true)
+        .build();
+
     // Tests have the following format:
     //      hhhh ssssssss dddddddddddddddddd ....
     // The `hhhh` part is the hexadecimal representation for f16,
@@ -14,9 +40,44 @@ fn run_test(line: &str) {
     let hex32 = line[5..13].to_lowercase();
     let hex64 = line[14..30].to_lowercase();
     let string = &line[31..];
+    let options = Options::new();
 
-    let float32 = f32::from_lexical(string.as_bytes()).unwrap();
-    let float64 = f64::from_lexical(string.as_bytes()).unwrap();
+    // now we want to add the number of digit separators we'll use
+    let count = rng.gen_range(1..=4);
+    let mut vec = string.as_bytes().to_vec();
+    let length = vec.len();
+    for _ in 0..count {
+        let idx = rng.gen_range(0..length);
+        vec.insert(idx, b'_');
+    }
+    // we need to make sure that our digit separators are in the correct location
+    // that is, they cannot be before a `+-` symbol
+    let string = str::from_utf8(&vec).unwrap();
+    let valid = SIGN.replace(string, "${2}${1}");
+
+    let float32 = f32::from_lexical_with_options::<FMT>(valid.as_bytes(), &options).unwrap();
+    let float64 = f64::from_lexical_with_options::<FMT>(valid.as_bytes(), &options).unwrap();
+    assert_eq!(hex32, format!("{:0>8x}", float32.to_bits()));
+    assert_eq!(hex64, format!("{:0>16x}", float64.to_bits()));
+}
+
+#[cfg(not(feature = "digit-separator"))]
+fn run_test<Random: Rng>(line: &str, _: &mut Random) {
+    const FMT: u128 = STANDARD;
+
+    // Tests have the following format:
+    //      hhhh ssssssss dddddddddddddddddd ....
+    // The `hhhh` part is the hexadecimal representation for f16,
+    // the `ssssssss` part is the hexadecimal representation of f32,
+    // the `dddddddddddddddddd` is the hex representation of f64,
+    // and the remaining bytes are the string to parse.
+    let hex32 = line[5..13].to_lowercase();
+    let hex64 = line[14..30].to_lowercase();
+    let string = &line[31..];
+    let options = Options::new();
+
+    let float32 = f32::from_lexical_with_options::<FMT>(string.as_bytes(), &options).unwrap();
+    let float64 = f64::from_lexical_with_options::<FMT>(string.as_bytes(), &options).unwrap();
     assert_eq!(hex32, format!("{:0>8x}", float32.to_bits()));
     assert_eq!(hex64, format!("{:0>16x}", float64.to_bits()));
 }
@@ -68,13 +129,14 @@ fn main() {
     ]);
 
     // Unfortunately, randomize the data with miri is too expensive so we just use it normally.
+    let mut rng = Isaac64Rng::from_seed(ISAAC_SEED);
     for (&filename, data) in tests.iter() {
         println!("Running Test: {}", filename);
         for (count, line) in data.lines().enumerate() {
             if cfg!(miri) && count % 10 == 0 {
                 println!("Running test {count} for conversion tests.");
             }
-            run_test(line);
+            run_test(line, &mut rng);
             if cfg!(miri) && count > 3000 {
                 break;
             }

--- a/lexical-parse-float/etc/correctness/test-parse-random/rand-f64.rs
+++ b/lexical-parse-float/etc/correctness/test-parse-random/rand-f64.rs
@@ -16,10 +16,10 @@ use rand_isaac::Isaac64Rng;
 use std::mem::transmute;
 
 fn main() {
-    let mut rnd = Isaac64Rng::from_seed(ISAAC_SEED);
+    let mut rng = Isaac64Rng::from_seed(ISAAC_SEED);
     let mut i = 0;
     while i < 10_000_000 {
-        let bits = rnd.next_u64();
+        let bits = rng.next_u64();
         let x: f64 = unsafe { transmute(bits) };
         if x.is_finite() {
             validate(&format!("{:e}", x));

--- a/lexical-parse-float/tests/issue_96_tests.rs
+++ b/lexical-parse-float/tests/issue_96_tests.rs
@@ -1,0 +1,435 @@
+#![cfg(feature = "format")]
+
+use core::num;
+
+use lexical_parse_float::{
+    Error,
+    FromLexical,
+    FromLexicalWithOptions,
+    NumberFormatBuilder,
+    Options,
+};
+use lexical_util::format::STANDARD;
+
+#[test]
+fn issue_96_test() {
+    let opts = Options::new();
+    const NO_CONSECUTIVE: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+    const CONSECUTIVE: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(true)
+        .build();
+    const NO_LEADING: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(false)
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(true)
+        .build();
+
+    let result = f64::from_lexical(b"_-1234");
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    let result = f64::from_lexical_with_options::<NO_CONSECUTIVE>(b"_-1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(1)));
+
+    let result = f64::from_lexical_with_options::<NO_LEADING>(b"^-1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    // NOTE: This uis correct, since it's "trailing"
+    let result = f64::from_lexical_with_options::<NO_LEADING>(b"_-1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(1)));
+
+    let result = f64::from_lexical_with_options::<NO_LEADING>(b"_1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    let result = f64::from_lexical_with_options::<NO_LEADING>(b"X1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    let result = f64::from_lexical_with_options::<NO_CONSECUTIVE>(b"__1__234__", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    let result = f64::from_lexical_with_options::<CONSECUTIVE>(b"__1__234__", &opts);
+    assert_eq!(result, Ok(1234f64));
+}
+
+#[test]
+fn issue_96_i_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .internal_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_1_", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((11f64, 3)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1_23", &opts);
+    assert_eq!(result, Ok((1123f64, 6)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1__23", &opts);
+    assert_eq!(result, Ok((11f64, 3)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1_23_", &opts);
+    assert_eq!(result, Ok((1123f64, 6)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1_23.", &opts);
+    assert_eq!(result, Ok((1123f64, 7)));
+}
+
+#[test]
+fn issue_96_l_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Ok((1f64, 2)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Ok((1f64, 3)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(1)));
+}
+
+#[test]
+fn issue_96_t_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123f64, 5)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123f64, 4)));
+}
+
+#[test]
+fn issue_96_il_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .internal_digit_separator(true)
+        .leading_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Ok((123f64, 5)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Ok((123f64, 6)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((11f64, 3)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1_", &opts);
+    assert_eq!(result, Ok((11f64, 3)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123f64, 4)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123f64, 4)));
+}
+
+#[test]
+fn issue_96_it_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(0)));
+
+    let result: Result<(f64, usize), Error> =
+        f64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((11f64, 3)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1_", &opts);
+    assert_eq!(result, Ok((11f64, 4)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123f64, 5)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123f64, 4)));
+}
+
+#[test]
+fn issue_96_lt_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Ok((1f64, 2)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Ok((1f64, 3)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1_", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_11_", &opts);
+    assert_eq!(result, Ok((11f64, 4)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::EmptyMantissa(1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123f64, 5)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123f64, 4)));
+}
+
+#[test]
+fn issue_96_no_required_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .required_digits(false)
+        .build();
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Ok((0f64, 0)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Ok((0f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Ok((0f64, 2)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Ok((1f64, 2)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Ok((1f64, 3)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"1_1_", &opts);
+    assert_eq!(result, Ok((1f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_11_", &opts);
+    assert_eq!(result, Ok((11f64, 4)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Ok((0f64, 1)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123f64, 5)));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123f64, 4)));
+}
+
+#[test]
+fn issue_96_rounding_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(true)
+        .build();
+    let input = b"0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002225073858507200889024586876085859887650423112240959465493524802562440009228235695178775888803759155264230978095043431208587738715835729182199302029437922422355981982750124204178896957131179108226104397197960400045489739193807919893608152561311337614984204327175103362739154978273159414382813627511383860409424946494228631669542910508020181592664213499660651780309507591305871984642390606863710200510872328278467884363194451586613504122347901479236958520832159762106637540161373658304419360371477835530668283453563400507407304013560296804637591858316312422452159926254649430083685186171942241764645513713542013221703137049658321015465406803539741790602258950302350193751977303094576317321085250729930508976158251915";
+    let result = f32::from_lexical_partial_with_options::<STANDARD>(input, &opts);
+    assert_eq!(result, Ok((0f32, input.len())));
+    let result = f32::from_lexical_partial_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok((0f32, input.len())));
+
+    let result = f64::from_lexical_partial_with_options::<STANDARD>(input, &opts);
+    assert_eq!(result, Ok((2.225073858507201e-308f64, input.len())));
+    let result = f64::from_lexical_partial_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok((2.225073858507201e-308f64, input.len())));
+
+    let input = b"_0e+___00";
+    let result = f32::from_lexical_partial_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok((0f32, input.len())));
+
+    let result = f32::from_lexical_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok(0f32));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok((0f64, input.len())));
+
+    let result = f64::from_lexical_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok(0f64));
+
+    let input = b"323081493377685546875e-297";
+    let result = f64::from_lexical_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok(3.2308149337768557e-277));
+
+    let input = b"32308_1493_3776_8554_6875e-297";
+    let result = f64::from_lexical_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok(3.2308149337768557e-277));
+}
+
+#[test]
+fn issue_96_wuff_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(true)
+        .build();
+    let input = b"0.000061094760894775390625";
+    let result = f32::from_lexical_partial_with_options::<STANDARD>(input, &opts);
+    assert_eq!(result, Ok((6.109476e-5f32, input.len())));
+
+    let result = f64::from_lexical_partial_with_options::<STANDARD>(input, &opts);
+    assert_eq!(result, Ok((6.109476089477539e-5, input.len())));
+
+    let input = b"0_.0000610_9476_0894775390_625";
+    let result = f32::from_lexical_partial_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok((6.109476e-5f32, input.len())));
+
+    let result = f64::from_lexical_partial_with_options::<FMT>(input, &opts);
+    assert_eq!(result, Ok((6.109476089477539e-5, input.len())));
+}

--- a/lexical-parse-float/tests/parse_tests.rs
+++ b/lexical-parse-float/tests/parse_tests.rs
@@ -78,7 +78,7 @@ fn parse_number_test() {
     let options = Options::new();
     let string = b"1.2345e10";
     let byte = string.bytes::<{ FORMAT }>();
-    let result = parse::parse_number(byte, false, &options);
+    let result = parse::parse_complete_number(byte, false, &options);
     assert!(result.is_ok());
     let num = result.unwrap();
     assert_eq!(num.mantissa, 12345);
@@ -87,12 +87,12 @@ fn parse_number_test() {
 
     let string = b"1.2345e";
     let byte = string.bytes::<{ FORMAT }>();
-    let result = parse::parse_number(byte, false, &options);
+    let result = parse::parse_complete_number(byte, false, &options);
     assert!(result.is_err());
 
     let string = b"1.2345 ";
     let byte = string.bytes::<{ FORMAT }>();
-    let result = parse::parse_number(byte, false, &options);
+    let result = parse::parse_complete_number(byte, false, &options);
     assert!(result.is_err());
 }
 

--- a/lexical-parse-integer/tests/issue_96_tests.rs
+++ b/lexical-parse-integer/tests/issue_96_tests.rs
@@ -1,0 +1,371 @@
+#![cfg(feature = "format")]
+
+use core::num;
+
+use lexical_parse_integer::{
+    Error,
+    FromLexical,
+    FromLexicalWithOptions,
+    NumberFormatBuilder,
+    Options,
+};
+
+#[test]
+fn issue_96_test() {
+    let opts = Options::new();
+    const NO_CONSECUTIVE: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+    const CONSECUTIVE: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(true)
+        .build();
+    const NO_LEADING: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(false)
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(true)
+        .build();
+
+    let result = i64::from_lexical(b"_-1234");
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    // NOTE: We need to make sure we're not skipping digit separators before the
+    // sign, which is never allowed.
+    let result = u64::from_lexical_with_options::<NO_CONSECUTIVE>(b"_-1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(1)));
+
+    let result = i64::from_lexical_with_options::<NO_CONSECUTIVE>(b"_-1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(1)));
+
+    let result = i64::from_lexical_with_options::<NO_LEADING>(b"^-1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    // NOTE: This uis correct, since it's "trailing"
+    let result = i64::from_lexical_with_options::<NO_LEADING>(b"_-1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(1)));
+
+    let result = i64::from_lexical_with_options::<NO_LEADING>(b"_1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    let result = i64::from_lexical_with_options::<NO_LEADING>(b"X1234", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    let result = i64::from_lexical_with_options::<NO_CONSECUTIVE>(b"__1__234__", &opts);
+    assert_eq!(result, Err(Error::InvalidDigit(0)));
+
+    let result = i64::from_lexical_with_options::<CONSECUTIVE>(b"__1__234__", &opts);
+    assert_eq!(result, Ok(1234));
+}
+
+#[test]
+fn issue_96_i_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .internal_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .required_digits(true)
+        .build();
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_1_", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((11, 3)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1_23", &opts);
+    assert_eq!(result, Ok((1123, 6)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1__23", &opts);
+    assert_eq!(result, Ok((11, 3)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1_23_", &opts);
+    assert_eq!(result, Ok((1123, 6)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1_23.", &opts);
+    assert_eq!(result, Ok((1123, 6)));
+}
+
+#[test]
+fn issue_96_l_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Ok((1, 2)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Ok((1, 3)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+}
+
+#[test]
+fn issue_96_t_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123, 5)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123, 4)));
+}
+
+#[test]
+fn issue_96_il_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .internal_digit_separator(true)
+        .leading_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Ok((123, 5)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Ok((123, 6)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((11, 3)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1_", &opts);
+    assert_eq!(result, Ok((11, 3)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123, 4)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123, 4)));
+}
+
+#[test]
+fn issue_96_it_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .internal_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((11, 3)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1_", &opts);
+    assert_eq!(result, Ok((11, 4)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123, 5)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123, 4)));
+}
+
+#[test]
+fn issue_96_lt_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .build();
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Err(Error::Empty(0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Err(Error::Empty(2)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Ok((1, 2)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Ok((1, 3)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1_", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_11_", &opts);
+    assert_eq!(result, Ok((11, 4)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Err(Error::Empty(1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123, 5)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123, 4)));
+}
+
+#[test]
+fn issue_96_no_required_test() {
+    let opts = Options::new();
+    const FMT: u128 = NumberFormatBuilder::new()
+        .digit_separator(num::NonZeroU8::new(b'_'))
+        .leading_digit_separator(true)
+        .trailing_digit_separator(true)
+        .consecutive_digit_separator(false)
+        .required_digits(false)
+        .build();
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"", &opts);
+    assert_eq!(result, Ok((0, 0)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_", &opts);
+    assert_eq!(result, Ok((0, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_", &opts);
+    assert_eq!(result, Ok((0, 2)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_1_23", &opts);
+    assert_eq!(result, Ok((1, 2)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+_1_23", &opts);
+    assert_eq!(result, Ok((1, 3)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1__1_23", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"1_1_", &opts);
+    assert_eq!(result, Ok((1, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_11_", &opts);
+    assert_eq!(result, Ok((11, 4)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"_+1_23", &opts);
+    assert_eq!(result, Ok((0, 1)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123_", &opts);
+    assert_eq!(result, Ok((123, 5)));
+
+    let result = i64::from_lexical_partial_with_options::<FMT>(b"+123__", &opts);
+    assert_eq!(result, Ok((123, 4)));
+}

--- a/lexical-util/src/feature_format.rs
+++ b/lexical-util/src/feature_format.rs
@@ -947,108 +947,188 @@ impl<const FORMAT: u128> NumberFormat<FORMAT> {
     // DIGIT SEPARATOR FLAGS & MASKS
 
     // If digit separators are allowed between integer digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     pub const INTEGER_INTERNAL_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, INTEGER_INTERNAL_DIGIT_SEPARATOR);
 
     /// Get if digit separators are allowed between integer digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn integer_internal_digit_separator(&self) -> bool {
         Self::INTEGER_INTERNAL_DIGIT_SEPARATOR
     }
 
     /// If digit separators are allowed between fraction digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     pub const FRACTION_INTERNAL_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, FRACTION_INTERNAL_DIGIT_SEPARATOR);
 
     /// Get if digit separators are allowed between fraction digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn fraction_internal_digit_separator(&self) -> bool {
         Self::FRACTION_INTERNAL_DIGIT_SEPARATOR
     }
 
     /// If digit separators are allowed between exponent digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     pub const EXPONENT_INTERNAL_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, EXPONENT_INTERNAL_DIGIT_SEPARATOR);
 
     /// Get if digit separators are allowed between exponent digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn exponent_internal_digit_separator(&self) -> bool {
         Self::EXPONENT_INTERNAL_DIGIT_SEPARATOR
     }
 
     /// If digit separators are allowed between digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     pub const INTERNAL_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, INTERNAL_DIGIT_SEPARATOR);
 
     /// Get if digit separators are allowed between digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn internal_digit_separator(&self) -> bool {
         Self::INTERNAL_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed before any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const INTEGER_LEADING_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, INTEGER_LEADING_DIGIT_SEPARATOR);
 
     /// Get if a digit separator is allowed before any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn integer_leading_digit_separator(&self) -> bool {
         Self::INTEGER_LEADING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed before any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const FRACTION_LEADING_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, FRACTION_LEADING_DIGIT_SEPARATOR);
 
     /// Get if a digit separator is allowed before any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn fraction_leading_digit_separator(&self) -> bool {
         Self::FRACTION_LEADING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed before any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const EXPONENT_LEADING_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, EXPONENT_LEADING_DIGIT_SEPARATOR);
 
     /// Get if a digit separator is allowed before any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn exponent_leading_digit_separator(&self) -> bool {
         Self::EXPONENT_LEADING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed before any digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const LEADING_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, LEADING_DIGIT_SEPARATOR);
 
     /// Get if a digit separator is allowed before any digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn leading_digit_separator(&self) -> bool {
         Self::LEADING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed after any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const INTEGER_TRAILING_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, INTEGER_TRAILING_DIGIT_SEPARATOR);
 
     /// Get if a digit separator is allowed after any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn integer_trailing_digit_separator(&self) -> bool {
         Self::INTEGER_TRAILING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed after any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const FRACTION_TRAILING_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, FRACTION_TRAILING_DIGIT_SEPARATOR);
 
     /// Get if a digit separator is allowed after any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn fraction_trailing_digit_separator(&self) -> bool {
         Self::FRACTION_TRAILING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed after any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const EXPONENT_TRAILING_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, EXPONENT_TRAILING_DIGIT_SEPARATOR);
 
     /// Get if a digit separator is allowed after any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn exponent_trailing_digit_separator(&self) -> bool {
         Self::EXPONENT_TRAILING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed after any digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const TRAILING_DIGIT_SEPARATOR: bool = from_flag!(FORMAT, TRAILING_DIGIT_SEPARATOR);
 
     /// Get if a digit separator is allowed after any digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn trailing_digit_separator(&self) -> bool {
         Self::TRAILING_DIGIT_SEPARATOR
@@ -1126,6 +1206,12 @@ impl<const FORMAT: u128> NumberFormat<FORMAT> {
         Self::BASE_PREFIX
     }
 
+    /// Get if the format has a base suffix.
+    #[inline(always)]
+    pub const fn has_base_prefix(&self) -> bool {
+        self.base_prefix() != 0
+    }
+
     /// The base suffix character in the packed struct.
     pub const BASE_SUFFIX: u8 = flags::base_suffix(FORMAT);
 
@@ -1138,6 +1224,12 @@ impl<const FORMAT: u128> NumberFormat<FORMAT> {
     #[inline(always)]
     pub const fn base_suffix(&self) -> u8 {
         Self::BASE_SUFFIX
+    }
+
+    /// Get if the format has a base suffix.
+    #[inline(always)]
+    pub const fn has_base_suffix(&self) -> bool {
+        self.base_suffix() != 0
     }
 
     // RADIX

--- a/lexical-util/src/format_builder.rs
+++ b/lexical-util/src/format_builder.rs
@@ -464,54 +464,84 @@ impl NumberFormatBuilder {
     }
 
     /// Get if digit separators are allowed between integer digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn get_integer_internal_digit_separator(&self) -> bool {
         self.integer_internal_digit_separator
     }
 
     /// Get if digit separators are allowed between fraction digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn get_fraction_internal_digit_separator(&self) -> bool {
         self.fraction_internal_digit_separator
     }
 
     /// Get if digit separators are allowed between exponent digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn get_exponent_internal_digit_separator(&self) -> bool {
         self.exponent_internal_digit_separator
     }
 
     /// Get if a digit separator is allowed before any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn get_integer_leading_digit_separator(&self) -> bool {
         self.integer_leading_digit_separator
     }
 
     /// Get if a digit separator is allowed before any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn get_fraction_leading_digit_separator(&self) -> bool {
         self.fraction_leading_digit_separator
     }
 
     /// Get if a digit separator is allowed before any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn get_exponent_leading_digit_separator(&self) -> bool {
         self.exponent_leading_digit_separator
     }
 
     /// Get if a digit separator is allowed after any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn get_integer_trailing_digit_separator(&self) -> bool {
         self.integer_trailing_digit_separator
     }
 
     /// Get if a digit separator is allowed after any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn get_fraction_trailing_digit_separator(&self) -> bool {
         self.fraction_trailing_digit_separator
     }
 
     /// Get if a digit separator is allowed after any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn get_exponent_trailing_digit_separator(&self) -> bool {
         self.exponent_trailing_digit_separator
@@ -754,6 +784,10 @@ impl NumberFormatBuilder {
     }
 
     /// Set if digit separators are allowed between integer digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn integer_internal_digit_separator(mut self, flag: bool) -> Self {
@@ -762,6 +796,10 @@ impl NumberFormatBuilder {
     }
 
     /// Set if digit separators are allowed between fraction digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn fraction_internal_digit_separator(mut self, flag: bool) -> Self {
@@ -770,6 +808,10 @@ impl NumberFormatBuilder {
     }
 
     /// Set if digit separators are allowed between exponent digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn exponent_internal_digit_separator(mut self, flag: bool) -> Self {
@@ -778,6 +820,10 @@ impl NumberFormatBuilder {
     }
 
     /// Set all internal digit separator flags.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn internal_digit_separator(mut self, flag: bool) -> Self {
@@ -788,6 +834,9 @@ impl NumberFormatBuilder {
     }
 
     /// Set if a digit separator is allowed before any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn integer_leading_digit_separator(mut self, flag: bool) -> Self {
@@ -796,6 +845,9 @@ impl NumberFormatBuilder {
     }
 
     /// Set if a digit separator is allowed before any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn fraction_leading_digit_separator(mut self, flag: bool) -> Self {
@@ -804,6 +856,9 @@ impl NumberFormatBuilder {
     }
 
     /// Set if a digit separator is allowed before any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn exponent_leading_digit_separator(mut self, flag: bool) -> Self {
@@ -812,6 +867,9 @@ impl NumberFormatBuilder {
     }
 
     /// Set all leading digit separator flags.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn leading_digit_separator(mut self, flag: bool) -> Self {
@@ -822,6 +880,9 @@ impl NumberFormatBuilder {
     }
 
     /// Set if a digit separator is allowed after any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn integer_trailing_digit_separator(mut self, flag: bool) -> Self {
@@ -830,6 +891,9 @@ impl NumberFormatBuilder {
     }
 
     /// Set if a digit separator is allowed after any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn fraction_trailing_digit_separator(mut self, flag: bool) -> Self {
@@ -838,6 +902,9 @@ impl NumberFormatBuilder {
     }
 
     /// Set if a digit separator is allowed after any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn exponent_trailing_digit_separator(mut self, flag: bool) -> Self {
@@ -846,6 +913,9 @@ impl NumberFormatBuilder {
     }
 
     /// Set all trailing digit separator flags.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     #[cfg(feature = "format")]
     pub const fn trailing_digit_separator(mut self, flag: bool) -> Self {

--- a/lexical-util/src/noskip.rs
+++ b/lexical-util/src/noskip.rs
@@ -125,15 +125,15 @@ unsafe impl<'a, const __: u128> Iter<'a> for Bytes<'a, __> {
         self.index = index;
     }
 
-    /// Get the current number of values returned by the iterator.
+    /// Get the current number of digits returned by the iterator.
+    ///
+    /// For contiguous iterators, this can include the sign character, decimal
+    /// point, and the exponent sign (that is, it is always the cursor). For
+    /// non-contiguous iterators, this must always be the only the number of
+    /// digits returned.
     #[inline(always)]
     fn current_count(&self) -> usize {
         self.index
-    }
-
-    #[inline(always)]
-    fn first(&self) -> Option<&'a u8> {
-        self.slc.get(self.index)
     }
 
     #[inline(always)]
@@ -241,6 +241,11 @@ impl<'a: 'b, 'b, const FORMAT: u128> DigitsIter<'a> for DigitsIterator<'a, 'b, F
     #[inline(always)]
     fn is_consumed(&mut self) -> bool {
         self.is_buffer_empty()
+    }
+
+    // Always a no-op
+    #[inline(always)]
+    fn increment_count(&mut self) {
     }
 
     #[inline(always)]

--- a/lexical-util/src/not_feature_format.rs
+++ b/lexical-util/src/not_feature_format.rs
@@ -274,108 +274,188 @@ impl<const FORMAT: u128> NumberFormat<FORMAT> {
     // DIGIT SEPARATOR FLAGS & MASKS
 
     // If digit separators are allowed between integer digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     pub const INTEGER_INTERNAL_DIGIT_SEPARATOR: bool = false;
 
     /// Get if digit separators are allowed between integer digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn integer_internal_digit_separator(&self) -> bool {
         Self::INTEGER_INTERNAL_DIGIT_SEPARATOR
     }
 
     /// If digit separators are allowed between fraction digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     pub const FRACTION_INTERNAL_DIGIT_SEPARATOR: bool = false;
 
     /// Get if digit separators are allowed between fraction digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn fraction_internal_digit_separator(&self) -> bool {
         Self::FRACTION_INTERNAL_DIGIT_SEPARATOR
     }
 
     /// If digit separators are allowed between exponent digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     pub const EXPONENT_INTERNAL_DIGIT_SEPARATOR: bool = false;
 
     /// Get if digit separators are allowed between exponent digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn exponent_internal_digit_separator(&self) -> bool {
         Self::EXPONENT_INTERNAL_DIGIT_SEPARATOR
     }
 
     /// If digit separators are allowed between digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     pub const INTERNAL_DIGIT_SEPARATOR: bool = false;
 
     /// Get if digit separators are allowed between digits.
+    ///
+    /// This will not consider an input of only the digit separator
+    /// to be a valid separator: the digit separator must be surrounded by
+    /// digits.
     #[inline(always)]
     pub const fn internal_digit_separator(&self) -> bool {
         Self::INTERNAL_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed before any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const INTEGER_LEADING_DIGIT_SEPARATOR: bool = false;
 
     /// Get if a digit separator is allowed before any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn integer_leading_digit_separator(&self) -> bool {
         Self::INTEGER_LEADING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed before any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const FRACTION_LEADING_DIGIT_SEPARATOR: bool = false;
 
     /// Get if a digit separator is allowed before any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn fraction_leading_digit_separator(&self) -> bool {
         Self::FRACTION_LEADING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed before any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const EXPONENT_LEADING_DIGIT_SEPARATOR: bool = false;
 
     /// Get if a digit separator is allowed before any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn exponent_leading_digit_separator(&self) -> bool {
         Self::EXPONENT_LEADING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed before any digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const LEADING_DIGIT_SEPARATOR: bool = false;
 
     /// Get if a digit separator is allowed before any digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn leading_digit_separator(&self) -> bool {
         Self::LEADING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed after any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const INTEGER_TRAILING_DIGIT_SEPARATOR: bool = false;
 
     /// Get if a digit separator is allowed after any integer digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn integer_trailing_digit_separator(&self) -> bool {
         Self::INTEGER_TRAILING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed after any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const FRACTION_TRAILING_DIGIT_SEPARATOR: bool = false;
 
     /// Get if a digit separator is allowed after any fraction digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn fraction_trailing_digit_separator(&self) -> bool {
         Self::FRACTION_TRAILING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed after any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const EXPONENT_TRAILING_DIGIT_SEPARATOR: bool = false;
 
     /// Get if a digit separator is allowed after any exponent digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn exponent_trailing_digit_separator(&self) -> bool {
         Self::EXPONENT_TRAILING_DIGIT_SEPARATOR
     }
 
     /// If a digit separator is allowed after any digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     pub const TRAILING_DIGIT_SEPARATOR: bool = false;
 
     /// Get if a digit separator is allowed after any digits.
+    ///
+    /// This will consider an input of only the digit separator
+    /// to be a identical to empty input.
     #[inline(always)]
     pub const fn trailing_digit_separator(&self) -> bool {
         Self::TRAILING_DIGIT_SEPARATOR
@@ -453,6 +533,12 @@ impl<const FORMAT: u128> NumberFormat<FORMAT> {
         Self::BASE_PREFIX
     }
 
+    /// Get if the format has a base prefix.
+    #[inline(always)]
+    pub const fn has_base_prefix(&self) -> bool {
+        false
+    }
+
     /// The base suffix character in the packed struct.
     pub const BASE_SUFFIX: u8 = 0;
 
@@ -465,6 +551,12 @@ impl<const FORMAT: u128> NumberFormat<FORMAT> {
     #[inline(always)]
     pub const fn base_suffix(&self) -> u8 {
         Self::BASE_SUFFIX
+    }
+
+    /// Get if the format has a base suffix.
+    #[inline(always)]
+    pub const fn has_base_suffix(&self) -> bool {
+        false
     }
 
     // RADIX

--- a/lexical-util/tests/iterator_tests.rs
+++ b/lexical-util/tests/iterator_tests.rs
@@ -89,10 +89,10 @@ fn skip_iterator_test() {
     assert_eq!(iter.current_count(), 0);
     unsafe { iter.step_unchecked() };
     assert_eq!(iter.cursor(), 1);
-    assert_eq!(iter.current_count(), 1);
+    assert_eq!(iter.current_count(), 0);
     iter.next();
     assert_eq!(iter.cursor(), 2);
-    assert_eq!(iter.current_count(), 2);
+    assert_eq!(iter.current_count(), 1);
 
     let mut byte = digits.bytes::<{ FORMAT }>();
     let mut iter = byte.integer_iter();

--- a/lexical-util/tests/skip_tests.rs
+++ b/lexical-util/tests/skip_tests.rs
@@ -31,27 +31,27 @@ fn test_skip_iter_i() {
     skip_iter_eq::<{ FORMAT }>(b"_.45", b"_.45");
     skip_iter_eq::<{ FORMAT }>(b"__.45", b"__.45");
     skip_iter_eq::<{ FORMAT }>(b"4_5", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"4__5", b"4_5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5", b"4__5");
     skip_iter_eq::<{ FORMAT }>(b"4_", b"4_");
     skip_iter_eq::<{ FORMAT }>(b"4__", b"4__");
     skip_iter_eq::<{ FORMAT }>(b"4_.", b"4_.");
     skip_iter_eq::<{ FORMAT }>(b"4__.", b"4__.");
     skip_iter_eq::<{ FORMAT }>(b"_45_5", b"_455");
-    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"__45_5");
+    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"__45__5");
     skip_iter_eq::<{ FORMAT }>(b"_.45_5", b"_.455");
-    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"__.45_5");
+    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"__.45__5");
     skip_iter_eq::<{ FORMAT }>(b"4_5_", b"45_");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4_5__");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4__5__");
     skip_iter_eq::<{ FORMAT }>(b"4_5_.5", b"45_.5");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4_5__.5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4__5__.5");
     skip_iter_eq::<{ FORMAT }>(b"_45_", b"_45_");
     skip_iter_eq::<{ FORMAT }>(b"__45__", b"__45__");
     skip_iter_eq::<{ FORMAT }>(b"_45_.56", b"_45_.56");
     skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"__45__.56");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_", b"_45_");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4_5__");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4__5__");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_.56", b"_45_.56");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4_5__.56");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4__5__.56");
 }
 
 #[test]
@@ -68,9 +68,9 @@ fn test_skip_iter_l() {
     skip_iter_eq::<{ FORMAT }>(b"1e", b"1e");
     skip_iter_eq::<{ FORMAT }>(b"1", b"1");
     skip_iter_eq::<{ FORMAT }>(b"_45", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"__45", b"_45");
+    skip_iter_eq::<{ FORMAT }>(b"__45", b"__45");
     skip_iter_eq::<{ FORMAT }>(b"_.45", b".45");
-    skip_iter_eq::<{ FORMAT }>(b"__.45", b"_.45");
+    skip_iter_eq::<{ FORMAT }>(b"__.45", b"__.45");
     skip_iter_eq::<{ FORMAT }>(b"4_5", b"4_5");
     skip_iter_eq::<{ FORMAT }>(b"4__5", b"4__5");
     skip_iter_eq::<{ FORMAT }>(b"4_", b"4_");
@@ -78,21 +78,21 @@ fn test_skip_iter_l() {
     skip_iter_eq::<{ FORMAT }>(b"4_.", b"4_.");
     skip_iter_eq::<{ FORMAT }>(b"4__.", b"4__.");
     skip_iter_eq::<{ FORMAT }>(b"_45_5", b"45_5");
-    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"_45__5");
+    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"__45__5");
     skip_iter_eq::<{ FORMAT }>(b"_.45_5", b".45_5");
-    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"_.45__5");
+    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"__.45__5");
     skip_iter_eq::<{ FORMAT }>(b"4_5_", b"4_5_");
     skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4__5__");
     skip_iter_eq::<{ FORMAT }>(b"4_5_.5", b"4_5_.5");
     skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4__5__.5");
     skip_iter_eq::<{ FORMAT }>(b"_45_", b"45_");
-    skip_iter_eq::<{ FORMAT }>(b"__45__", b"_45__");
+    skip_iter_eq::<{ FORMAT }>(b"__45__", b"__45__");
     skip_iter_eq::<{ FORMAT }>(b"_45_.56", b"45_.56");
-    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"_45__.56");
+    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"__45__.56");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_", b"4_5_");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"_4__5__");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4__5__");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_.56", b"4_5_.56");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"_4__5__.56");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4__5__.56");
 }
 
 #[test]
@@ -111,29 +111,29 @@ fn test_skip_iter_t() {
     skip_iter_eq::<{ FORMAT }>(b"_45", b"_45");
     skip_iter_eq::<{ FORMAT }>(b"__45", b"__45");
     skip_iter_eq::<{ FORMAT }>(b"_.45", b".45");
-    skip_iter_eq::<{ FORMAT }>(b"__.45", b"_.45");
+    skip_iter_eq::<{ FORMAT }>(b"__.45", b"__.45");
     skip_iter_eq::<{ FORMAT }>(b"4_5", b"4_5");
     skip_iter_eq::<{ FORMAT }>(b"4__5", b"4__5");
     skip_iter_eq::<{ FORMAT }>(b"4_", b"4");
-    skip_iter_eq::<{ FORMAT }>(b"4__", b"4_");
+    skip_iter_eq::<{ FORMAT }>(b"4__", b"4__");
     skip_iter_eq::<{ FORMAT }>(b"4_.", b"4.");
-    skip_iter_eq::<{ FORMAT }>(b"4__.", b"4_.");
+    skip_iter_eq::<{ FORMAT }>(b"4__.", b"4__.");
     skip_iter_eq::<{ FORMAT }>(b"_45_5", b"_45_5");
     skip_iter_eq::<{ FORMAT }>(b"__45__5", b"__45__5");
     skip_iter_eq::<{ FORMAT }>(b"_.45_5", b".45_5");
-    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"_.45__5");
+    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"__.45__5");
     skip_iter_eq::<{ FORMAT }>(b"4_5_", b"4_5");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4__5_");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4__5__");
     skip_iter_eq::<{ FORMAT }>(b"4_5_.5", b"4_5.5");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4__5_.5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4__5__.5");
     skip_iter_eq::<{ FORMAT }>(b"_45_", b"_45");
-    skip_iter_eq::<{ FORMAT }>(b"__45__", b"__45_");
+    skip_iter_eq::<{ FORMAT }>(b"__45__", b"__45__");
     skip_iter_eq::<{ FORMAT }>(b"_45_.56", b"_45.56");
-    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"__45_.56");
+    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"__45__.56");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_", b"_4_5");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4__5_");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4__5__");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_.56", b"_4_5.56");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4__5_.56");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4__5__.56");
 }
 
 #[test]
@@ -151,31 +151,31 @@ fn test_skip_iter_il() {
     skip_iter_eq::<{ FORMAT }>(b"1e", b"1e");
     skip_iter_eq::<{ FORMAT }>(b"1", b"1");
     skip_iter_eq::<{ FORMAT }>(b"_45", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"__45", b"_45");
+    skip_iter_eq::<{ FORMAT }>(b"__45", b"__45");
     skip_iter_eq::<{ FORMAT }>(b"_.45", b".45");
-    skip_iter_eq::<{ FORMAT }>(b"__.45", b"_.45");
+    skip_iter_eq::<{ FORMAT }>(b"__.45", b"__.45");
     skip_iter_eq::<{ FORMAT }>(b"4_5", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"4__5", b"4_5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5", b"4__5");
     skip_iter_eq::<{ FORMAT }>(b"4_", b"4_");
     skip_iter_eq::<{ FORMAT }>(b"4__", b"4__");
     skip_iter_eq::<{ FORMAT }>(b"4_.", b"4_.");
     skip_iter_eq::<{ FORMAT }>(b"4__.", b"4__.");
     skip_iter_eq::<{ FORMAT }>(b"_45_5", b"455");
-    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"_45_5");
+    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"__45__5");
     skip_iter_eq::<{ FORMAT }>(b"_.45_5", b".455");
-    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"_.45_5");
+    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"__.45__5");
     skip_iter_eq::<{ FORMAT }>(b"4_5_", b"45_");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4_5__");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4__5__");
     skip_iter_eq::<{ FORMAT }>(b"4_5_.5", b"45_.5");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4_5__.5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4__5__.5");
     skip_iter_eq::<{ FORMAT }>(b"_45_", b"45_");
-    skip_iter_eq::<{ FORMAT }>(b"__45__", b"_45__");
+    skip_iter_eq::<{ FORMAT }>(b"__45__", b"__45__");
     skip_iter_eq::<{ FORMAT }>(b"_45_.56", b"45_.56");
-    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"_45__.56");
+    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"__45__.56");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_", b"45_");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"_4_5__");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4__5__");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_.56", b"45_.56");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"_4_5__.56");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4__5__.56");
 }
 
 #[test]
@@ -195,29 +195,29 @@ fn test_skip_iter_it() {
     skip_iter_eq::<{ FORMAT }>(b"_45", b"_45");
     skip_iter_eq::<{ FORMAT }>(b"__45", b"__45");
     skip_iter_eq::<{ FORMAT }>(b"_.45", b".45");
-    skip_iter_eq::<{ FORMAT }>(b"__.45", b"_.45");
+    skip_iter_eq::<{ FORMAT }>(b"__.45", b"__.45");
     skip_iter_eq::<{ FORMAT }>(b"4_5", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"4__5", b"4_5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5", b"4__5");
     skip_iter_eq::<{ FORMAT }>(b"4_", b"4");
-    skip_iter_eq::<{ FORMAT }>(b"4__", b"4_");
+    skip_iter_eq::<{ FORMAT }>(b"4__", b"4__");
     skip_iter_eq::<{ FORMAT }>(b"4_.", b"4.");
-    skip_iter_eq::<{ FORMAT }>(b"4__.", b"4_.");
+    skip_iter_eq::<{ FORMAT }>(b"4__.", b"4__.");
     skip_iter_eq::<{ FORMAT }>(b"_45_5", b"_455");
-    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"__45_5");
+    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"__45__5");
     skip_iter_eq::<{ FORMAT }>(b"_.45_5", b".455");
-    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"_.45_5");
+    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"__.45__5");
     skip_iter_eq::<{ FORMAT }>(b"4_5_", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4_5_");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4__5__");
     skip_iter_eq::<{ FORMAT }>(b"4_5_.5", b"45.5");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4_5_.5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4__5__.5");
     skip_iter_eq::<{ FORMAT }>(b"_45_", b"_45");
-    skip_iter_eq::<{ FORMAT }>(b"__45__", b"__45_");
+    skip_iter_eq::<{ FORMAT }>(b"__45__", b"__45__");
     skip_iter_eq::<{ FORMAT }>(b"_45_.56", b"_45.56");
-    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"__45_.56");
+    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"__45__.56");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_", b"_45");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4_5_");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4__5__");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_.56", b"_45.56");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4_5_.56");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4__5__.56");
 }
 
 #[test]
@@ -235,31 +235,31 @@ fn test_skip_iter_lt() {
     skip_iter_eq::<{ FORMAT }>(b"1e", b"1e");
     skip_iter_eq::<{ FORMAT }>(b"1", b"1");
     skip_iter_eq::<{ FORMAT }>(b"_45", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"__45", b"_45");
+    skip_iter_eq::<{ FORMAT }>(b"__45", b"__45");
     skip_iter_eq::<{ FORMAT }>(b"_.45", b".45");
-    skip_iter_eq::<{ FORMAT }>(b"__.45", b"_.45");
+    skip_iter_eq::<{ FORMAT }>(b"__.45", b"__.45");
     skip_iter_eq::<{ FORMAT }>(b"4_5", b"4_5");
     skip_iter_eq::<{ FORMAT }>(b"4__5", b"4__5");
     skip_iter_eq::<{ FORMAT }>(b"4_", b"4");
-    skip_iter_eq::<{ FORMAT }>(b"4__", b"4_");
+    skip_iter_eq::<{ FORMAT }>(b"4__", b"4__");
     skip_iter_eq::<{ FORMAT }>(b"4_.", b"4.");
-    skip_iter_eq::<{ FORMAT }>(b"4__.", b"4_.");
+    skip_iter_eq::<{ FORMAT }>(b"4__.", b"4__.");
     skip_iter_eq::<{ FORMAT }>(b"_45_5", b"45_5");
-    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"_45__5");
+    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"__45__5");
     skip_iter_eq::<{ FORMAT }>(b"_.45_5", b".45_5");
-    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"_.45__5");
+    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"__.45__5");
     skip_iter_eq::<{ FORMAT }>(b"4_5_", b"4_5");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4__5_");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4__5__");
     skip_iter_eq::<{ FORMAT }>(b"4_5_.5", b"4_5.5");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4__5_.5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4__5__.5");
     skip_iter_eq::<{ FORMAT }>(b"_45_", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"__45__", b"_45_");
+    skip_iter_eq::<{ FORMAT }>(b"__45__", b"__45__");
     skip_iter_eq::<{ FORMAT }>(b"_45_.56", b"45.56");
-    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"_45_.56");
+    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"__45__.56");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_", b"4_5");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"_4__5_");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4__5__");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_.56", b"4_5.56");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"_4__5_.56");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4__5__.56");
 }
 
 #[test]
@@ -278,31 +278,31 @@ fn test_skip_iter_ilt() {
     skip_iter_eq::<{ FORMAT }>(b"1e", b"1e");
     skip_iter_eq::<{ FORMAT }>(b"1", b"1");
     skip_iter_eq::<{ FORMAT }>(b"_45", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"__45", b"_45");
+    skip_iter_eq::<{ FORMAT }>(b"__45", b"__45");
     skip_iter_eq::<{ FORMAT }>(b"_.45", b".45");
-    skip_iter_eq::<{ FORMAT }>(b"__.45", b"_.45");
+    skip_iter_eq::<{ FORMAT }>(b"__.45", b"__.45");
     skip_iter_eq::<{ FORMAT }>(b"4_5", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"4__5", b"4_5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5", b"4__5");
     skip_iter_eq::<{ FORMAT }>(b"4_", b"4");
-    skip_iter_eq::<{ FORMAT }>(b"4__", b"4_");
+    skip_iter_eq::<{ FORMAT }>(b"4__", b"4__");
     skip_iter_eq::<{ FORMAT }>(b"4_.", b"4.");
-    skip_iter_eq::<{ FORMAT }>(b"4__.", b"4_.");
+    skip_iter_eq::<{ FORMAT }>(b"4__.", b"4__.");
     skip_iter_eq::<{ FORMAT }>(b"_45_5", b"455");
-    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"_45_5");
+    skip_iter_eq::<{ FORMAT }>(b"__45__5", b"__45__5");
     skip_iter_eq::<{ FORMAT }>(b"_.45_5", b".455");
-    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"_.45_5");
+    skip_iter_eq::<{ FORMAT }>(b"__.45__5", b"__.45__5");
     skip_iter_eq::<{ FORMAT }>(b"4_5_", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4_5_");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__", b"4__5__");
     skip_iter_eq::<{ FORMAT }>(b"4_5_.5", b"45.5");
-    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4_5_.5");
+    skip_iter_eq::<{ FORMAT }>(b"4__5__.5", b"4__5__.5");
     skip_iter_eq::<{ FORMAT }>(b"_45_", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"__45__", b"_45_");
+    skip_iter_eq::<{ FORMAT }>(b"__45__", b"__45__");
     skip_iter_eq::<{ FORMAT }>(b"_45_.56", b"45.56");
-    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"_45_.56");
+    skip_iter_eq::<{ FORMAT }>(b"__45__.56", b"__45__.56");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_", b"45");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"_4_5_");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__", b"__4__5__");
     skip_iter_eq::<{ FORMAT }>(b"_4_5_.56", b"45.56");
-    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"_4_5_.56");
+    skip_iter_eq::<{ FORMAT }>(b"__4__5__.56", b"__4__5__.56");
 }
 
 #[test]


### PR DESCRIPTION
This addressed #96 and #97, fixing the lack of processing with consecutive digit separators by enhancing the internal logic, adds logic for internal and first digit separators to simplify logic and improve performance, fix unittests, and also make it so the errors are consistent by adding checks when formatting is enabled to ensure the correct logic is used.

Closes #96
Closes #97