### PR TITLE
Add patches for feature configurations and serializing radices.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Have consistent errors when an invalid leading digit is found for floating point numbers to always be `Error::InvalidDigit`.
 - Incorrect parsing of consecutive digit separators.
 - Inaccuracies when parsing digit separators at various positions leading to incorect errors being returned.
+- Selecting only a subset of parse and/or write features would cause compilation errors.
+- Fixed bug with writing integers with custom radices.
 
 ## [1.0.1] 2024-09-16
 

--- a/lexical-core/Cargo.toml
+++ b/lexical-core/Cargo.toml
@@ -107,7 +107,9 @@ f16 = [
     "lexical-write-float?/f16"
 ]
 
-# Internal only features.
+# INTERNAL ONLY
+# -------------
+# Internal only features. These are not meant to be used directly.
 # Enable the lint checks.
 lint = [
     "lexical-util/lint",
@@ -117,16 +119,23 @@ lint = [
     "lexical-parse-float?/lint"
 ]
 # Add support for writing numbers.
-write = []
+# Library users should use `write-integers` and `write-floats` instead.
+write = ["lexical-util/write"]
 # Add support for parsing numbers.
-parse = []
+# Library users should use `parse-integers` and `parse-floats` instead.
+parse = ["lexical-util/parse"]
 # Add support for conversions to or from integers.
-integers = []
+# Library users should use `write-integers` and `parse-integers` instead.
+integers = ["lexical-util/integers"]
 # Add support for conversions to or from floats.
-floats = []
+# Library users should use `write-floats` and `parse-floats` instead.
+floats = ["lexical-util/floats"]
 
-# Currently unsupported.
-# Enable support for 128-bit floats.
+# UNSUPPORTED
+# -----------
+# Currently unsupported features.
+# Enable support for 128-bit floats. Unsupported and unlikely to ever be.
+#   https://github.com/Alexhuszagh/rust-lexical/issues/46
 f128 = [
     "lexical-util/f128",
     "lexical-parse-float?/f128",

--- a/lexical-core/tests/float_pow2_tests.rs
+++ b/lexical-core/tests/float_pow2_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "radix")]
+#![cfg(feature = "power-of-two")]
 #![cfg(feature = "parse-floats")]
 #![cfg(feature = "write-floats")]
 
@@ -99,51 +99,22 @@ macro_rules! test_radix {
 macro_rules! test_all {
     ($f:ident, $buffer:ident, $data:ident) => {{
         test_radix!($f, 2, $buffer, $data);
-        test_radix!($f, 3, $buffer, $data);
         test_radix!($f, 4, $buffer, $data);
-        test_radix!($f, 5, $buffer, $data);
-        test_radix!($f, 6, $buffer, $data);
-        test_radix!($f, 7, $buffer, $data);
         test_radix!($f, 8, $buffer, $data);
-        test_radix!($f, 9, $buffer, $data);
-        test_radix!($f, 19, $buffer, $data);
-        test_radix!($f, 11, $buffer, $data);
-        test_radix!($f, 12, $buffer, $data);
-        test_radix!($f, 13, $buffer, $data);
-        test_radix!($f, 14, $buffer, $data);
-        test_radix!($f, 15, $buffer, $data);
         test_radix!($f, 16, $buffer, $data);
-        test_radix!($f, 17, $buffer, $data);
-        test_radix!($f, 18, $buffer, $data);
-        test_radix!($f, 19, $buffer, $data);
-        test_radix!($f, 20, $buffer, $data);
-        test_radix!($f, 21, $buffer, $data);
-        test_radix!($f, 22, $buffer, $data);
-        test_radix!($f, 23, $buffer, $data);
-        test_radix!($f, 24, $buffer, $data);
-        test_radix!($f, 25, $buffer, $data);
-        test_radix!($f, 26, $buffer, $data);
-        test_radix!($f, 27, $buffer, $data);
-        test_radix!($f, 28, $buffer, $data);
-        test_radix!($f, 29, $buffer, $data);
-        test_radix!($f, 30, $buffer, $data);
-        test_radix!($f, 31, $buffer, $data);
         test_radix!($f, 32, $buffer, $data);
-        test_radix!($f, 33, $buffer, $data);
-        test_radix!($f, 34, $buffer, $data);
-        test_radix!($f, 35, $buffer, $data);
         test_radix!($f, 36, $buffer, $data);
     }};
 }
 
 #[test]
-fn parse_f32_radix_roundtrip_test() {
+fn parse_f32_pow2_roundtrip_test() {
     let mut buffer = [0u8; 1024];
     test_all!(f32, buffer, F32_DATA);
 }
 
 #[test]
-fn parse_f64_radix_roundtrip_test() {
+fn parse_f64_pow2_roundtrip_test() {
     let mut buffer = [0u8; 1024];
     test_all!(f64, buffer, F64_DATA);
 }

--- a/lexical-parse-float/Cargo.toml
+++ b/lexical-parse-float/Cargo.toml
@@ -71,15 +71,20 @@ compact = [
 # Enable support for 16-bit floats.
 f16 = ["lexical-util/f16"]
 
-# Internal only features.
+# INTERNAL ONLY
+# -------------
+# Internal only features. These are not meant to be used directly.
 # Enable the lint checks.
 lint = [
     "lexical-util/lint",
     "lexical-parse-integer/lint"
 ]
 
-# Currently unsupported.
-# Enable support for 128-bit floats.
+# UNSUPPORTED
+# -----------
+# Currently unsupported features.
+# Enable support for 128-bit floats. Unsupported and unlikely to ever be.
+#   https://github.com/Alexhuszagh/rust-lexical/issues/46
 f128 = ["lexical-util/f128"]
 
 [package.metadata.docs.rs]

--- a/lexical-parse-integer/Cargo.toml
+++ b/lexical-parse-integer/Cargo.toml
@@ -47,7 +47,9 @@ format = ["lexical-util/format"]
 # Reduce code size at the cost of performance.
 compact = ["lexical-util/compact"]
 
-# Internal only features.
+# INTERNAL ONLY
+# -------------
+# Internal only features. These are not meant to be used directly.
 # Enable the lint checks.
 lint = ["lexical-util/lint"]
 

--- a/lexical-util/Cargo.toml
+++ b/lexical-util/Cargo.toml
@@ -55,6 +55,8 @@ parse-integers = ["parse", "integers"]
 parse-floats = ["parse", "floats"]
 # Reduce code size at the cost of performance.
 compact = []
+# Add support for the `f16` and `b16` half-point floating point numbers.
+f16 = ["parse-floats", "write-floats"]
 
 # Internal only features.
 # Enable the lint checks.
@@ -68,11 +70,14 @@ integers = []
 # Add support for conversions to or from floats.
 floats = []
 
-# Currently unsupported.
+# UNSUPPORTED
+# -----------
+# Currently unsupported features.
+# Enable support for 128-bit floats. Unsupported and unlikely to ever be.
+#   https://github.com/Alexhuszagh/rust-lexical/issues/46
 # Enable support for 16-bit floats.
-f16 = ["floats"]
 # Enable support for 128-bit floats.
-f128 = ["floats"]
+f128 = ["parse-floats", "write-floats"]
 
 [package.metadata.docs.rs]
 features = ["radix", "format", "write-integers", "write-floats", "parse-integers", "parse-floats"]

--- a/lexical-util/src/lib.rs
+++ b/lexical-util/src/lib.rs
@@ -132,6 +132,26 @@
     clippy::semicolon_inside_block,
 )]
 
+// Ensure our features are properly enabled. This means no parse without
+// parse support, etc.
+#[cfg(all(feature = "parse", not(any(feature = "parse-integers", feature = "parse-floats"))))]
+compile_error!(
+    "Do not use the `parse` feature directly. Use `parse-integers` and/or `parse-floats` instead."
+);
+
+#[cfg(all(feature = "write", not(any(feature = "write-integers", feature = "write-floats"))))]
+compile_error!(
+    "Do not use the `write` feature directly. Use `write-integers` and/or `write-floats` instead."
+);
+
+#[cfg(all(feature = "integers", not(any(feature = "write-integers", feature = "parse-integers"))))]
+compile_error!("Do not use the `integers` feature directly. Use `write-integers` and/or `parse-integers` instead.");
+
+#[cfg(all(feature = "floats", not(any(feature = "write-floats", feature = "parse-floats"))))]
+compile_error!(
+    "Do not use the `floats` feature directly. Use `write-floats` and/or `parse-floats` instead."
+);
+
 pub mod algorithm;
 pub mod ascii;
 pub mod assert;

--- a/lexical-write-float/Cargo.toml
+++ b/lexical-write-float/Cargo.toml
@@ -70,15 +70,20 @@ compact = [
 # Enable support for 16-bit floats.
 f16 = ["lexical-util/f16"]
 
-# Internal only features.
+# INTERNAL ONLY
+# -------------
+# Internal only features. These are not meant to be used directly.
 # Enable the lint checks.
 lint = [
     "lexical-util/lint",
     "lexical-write-integer/lint"
 ]
 
-# Currently unsupported.
-# Enable support for 128-bit floats.
+# UNSUPPORTED
+# -----------
+# Currently unsupported features.
+# Enable support for 128-bit floats. Unsupported and unlikely to ever be.
+#   https://github.com/Alexhuszagh/rust-lexical/issues/46
 f128 = ["lexical-util/f128"]
 
 [package.metadata.docs.rs]

--- a/lexical-write-integer/Cargo.toml
+++ b/lexical-write-integer/Cargo.toml
@@ -47,7 +47,9 @@ format = ["lexical-util/format"]
 # Reduce code size at the cost of performance.
 compact = ["lexical-util/compact"]
 
-# Internal only features.
+# INTERNAL ONLY
+# -------------
+# Internal only features. These are not meant to be used directly.
 # Enable the lint checks.
 lint = ["lexical-util/lint"]
 

--- a/lexical-write-integer/src/algorithm.rs
+++ b/lexical-write-integer/src/algorithm.rs
@@ -16,8 +16,6 @@ use lexical_util::format::{radix_from_flags, NumberFormat};
 use lexical_util::num::{AsCast, UnsignedInteger};
 use lexical_util::step::u64_step;
 
-use crate::decimal::DigitCount;
-
 /// Write 2 digits to buffer.
 ///
 /// # Safety
@@ -80,18 +78,16 @@ macro_rules! write_digit {
 /// See [algorithm] and the [crate] documentation for more detailed
 /// information on the safety considerations.
 #[inline(always)]
-unsafe fn write_digits<T: UnsignedInteger + DigitCount>(
+unsafe fn write_digits<T: UnsignedInteger>(
     mut value: T,
     radix: u32,
     table: &[u8],
     buffer: &mut [u8],
     mut index: usize,
+    count: usize,
 ) -> usize {
     debug_assert_radix(radix);
-    debug_assert!(
-        buffer.len() >= value.digit_count(),
-        "buffer must at least be as the digit count"
-    );
+    debug_assert!(buffer.len() >= count, "buffer must at least be as the digit count");
 
     // Pre-compute our powers of radix.
     let radix = T::from_u32(radix);
@@ -153,19 +149,20 @@ unsafe fn write_digits<T: UnsignedInteger + DigitCount>(
 /// This is safe as long as the buffer is large enough to hold `T::MAX`
 /// digits in radix `N`. See [algorithm] for more safety considerations.
 #[inline(always)]
-unsafe fn write_step_digits<T: UnsignedInteger + DigitCount>(
+unsafe fn write_step_digits<T: UnsignedInteger>(
     value: T,
     radix: u32,
     table: &[u8],
     buffer: &mut [u8],
     index: usize,
     step: usize,
+    count: usize,
 ) -> usize {
     debug_assert_radix(radix);
 
     let start = index;
     // SAFETY: safe as long as the call to write_step_digits is safe.
-    let index = unsafe { write_digits(value, radix, table, buffer, index) };
+    let index = unsafe { write_digits(value, radix, table, buffer, index, count) };
     // Write the remaining 0 bytes.
     let end = start.saturating_sub(step);
     // SAFETY: this is always safe since `end < index && index < start`.
@@ -188,16 +185,15 @@ unsafe fn write_step_digits<T: UnsignedInteger + DigitCount>(
 ///
 /// [`digit_count`]: `crate::decimal::DigitCount`
 #[inline(always)]
-pub fn algorithm<T>(value: T, radix: u32, table: &[u8], buffer: &mut [u8]) -> usize
+pub fn algorithm<T>(value: T, radix: u32, table: &[u8], buffer: &mut [u8], count: usize) -> usize
 where
-    T: UnsignedInteger + DigitCount,
+    T: UnsignedInteger,
 {
     // This is so that radix^4 does not overflow, since 36^4 overflows a u16.
     assert!(T::BITS >= 32, "Must have at least 32 bits in the input.");
     assert!(radix <= 36, "radix must be <= 36");
     assert!(table.len() >= (radix * radix * 2) as usize, "table must be 2 * radix^2 long");
 
-    let count = value.digit_count();
     assert!(count <= buffer.len());
     let buffer = &mut buffer[..count];
 
@@ -206,8 +202,7 @@ where
     // The buffer is ensured to have at least `FORMATTED_SIZE` or
     // `FORMATTED_SIZE_DECIMAL` characters, which is the maximum number of
     // digits an integer of that size may write.
-    unsafe { write_digits(value, radix, table, buffer, buffer.len()) };
-    count
+    unsafe { write_digits(value, radix, table, buffer, buffer.len(), count) }
 }
 
 /// Optimized implementation for radix-N 128-bit numbers.
@@ -227,12 +222,12 @@ pub fn algorithm_u128<const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
     value: u128,
     table: &[u8],
     buffer: &mut [u8],
+    count: usize,
 ) -> usize {
     // NOTE: Use the const version of radix for u64_step and
     // u128_divrem to ensure they're evaluated at compile time.
     assert!(NumberFormat::<{ FORMAT }> {}.is_valid());
 
-    let count = value.digit_count();
     assert!(count <= buffer.len());
     let buffer = &mut buffer[..count];
 
@@ -244,7 +239,7 @@ pub fn algorithm_u128<const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
     assert!(table.len() >= (radix * radix * 2) as usize, "table must be 2 * radix^2 long");
     if value <= u64::MAX as u128 {
         // SAFETY: safe if the buffer is large enough to hold the significant digits.
-        return unsafe { algorithm(value as u64, radix, table, buffer) };
+        return unsafe { algorithm(value as u64, radix, table, buffer, count) };
     }
 
     // LOGIC: Both forms of unchecked indexing cannot overflow.
@@ -263,18 +258,18 @@ pub fn algorithm_u128<const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
     let step = u64_step(radix_from_flags(FORMAT, MASK, SHIFT));
     let (value, low) = u128_divrem(value, radix_from_flags(FORMAT, MASK, SHIFT));
     let mut index = buffer.len();
-    index = unsafe { write_step_digits(low, radix, table, buffer, index, step) };
+    index = unsafe { write_step_digits(low, radix, table, buffer, index, step, count) };
     if value <= u64::MAX as u128 {
-        unsafe { write_digits(value as u64, radix, table, buffer, index) };
+        unsafe { write_digits(value as u64, radix, table, buffer, index, count) };
         return count;
     }
 
     // Value has to be greater than 1.8e38
     let (value, mid) = u128_divrem(value, radix_from_flags(FORMAT, MASK, SHIFT));
-    index = unsafe { write_step_digits(mid, radix, table, buffer, index, step) };
+    index = unsafe { write_step_digits(mid, radix, table, buffer, index, step, count) };
     if index != 0 {
-        unsafe { write_digits(value as u64, radix, table, buffer, index) };
+        index = unsafe { write_digits(value as u64, radix, table, buffer, index, count) };
     }
 
-    count
+    index
 }

--- a/lexical-write-integer/src/decimal.rs
+++ b/lexical-write-integer/src/decimal.rs
@@ -259,7 +259,9 @@ macro_rules! decimal_impl {
         impl Decimal for $t {
             #[inline(always)]
             fn decimal(self, buffer: &mut [u8]) -> usize {
-                algorithm(self, 10, &DIGIT_TO_BASE10_SQUARED, buffer)
+                let count = self.digit_count();
+                let _ = algorithm(self, 10, &DIGIT_TO_BASE10_SQUARED, buffer, count);
+                count
             }
         }
     )*);
@@ -270,10 +272,13 @@ decimal_impl! { u32 u64 }
 impl Decimal for u128 {
     #[inline(always)]
     fn decimal(self, buffer: &mut [u8]) -> usize {
-        algorithm_u128::<{ STANDARD }, { RADIX }, { RADIX_SHIFT }>(
+        let count = self.digit_count();
+        let _ = algorithm_u128::<{ STANDARD }, { RADIX }, { RADIX_SHIFT }>(
             self,
             &DIGIT_TO_BASE10_SQUARED,
             buffer,
-        )
+            count,
+        );
+        count
     }
 }

--- a/lexical-write-integer/src/radix.rs
+++ b/lexical-write-integer/src/radix.rs
@@ -59,8 +59,9 @@ macro_rules! radix_impl {
                 let radix = format::radix_from_flags(FORMAT, MASK, SHIFT);
                 let table = get_table::<FORMAT, MASK, SHIFT>();
                 let mut digits: [u8; 64] = [0u8; 64];
+                let count = digits.len();
                 // SAFETY: Safe since 64 bytes is always enough to hold the digits of a <= 64 bit integer.
-                let index = unsafe { algorithm(self, radix, table, &mut digits) };
+                let index = unsafe { algorithm(self, radix, table, &mut digits, count) };
                 copy_to_dst(buffer, &mut digits[index..])
             }
         }
@@ -77,9 +78,11 @@ impl Radix for u128 {
     ) -> usize {
         let table = get_table::<FORMAT, MASK, SHIFT>();
         let mut digits: [u8; 128] = [0u8; 128];
+        let count = digits.len();
         // SAFETY: Safe since 128 bytes is always enough to hold the digits of a 128 bit
         // integer.
-        let index = unsafe { algorithm_u128::<FORMAT, MASK, SHIFT>(self, table, &mut digits) };
+        let index =
+            unsafe { algorithm_u128::<FORMAT, MASK, SHIFT>(self, table, &mut digits, count) };
         copy_to_dst(buffer, &mut digits[index..])
     }
 }

--- a/lexical/Cargo.toml
+++ b/lexical/Cargo.toml
@@ -46,20 +46,29 @@ compact = ["lexical-core/compact"]
 # Enable support for 16-bit floats.
 f16 = ["lexical-core/f16"]
 
-# Internal only features.
+# INTERNAL ONLY
+# -------------
+# Internal only features. These are not meant to be used directly.
 # Enable the lint checks.
 lint = ["lexical-core/lint"]
 # Add support for writing numbers.
-write = []
+# Library users should use `write-integers` and `write-floats` instead.
+write = ["lexical-core/write"]
 # Add support for parsing numbers.
-parse = []
+# Library users should use `parse-integers` and `parse-floats` instead.
+parse = ["lexical-core/parse"]
 # Add support for conversions to or from integers.
-integers = []
+# Library users should use `write-integers` and `parse-integers` instead.
+integers = ["lexical-core/integers"]
 # Add support for conversions to or from floats.
-floats = []
+# Library users should use `write-floats` and `parse-floats` instead.
+floats = ["lexical-core/floats"]
 
-# Currently unsupported.
-# Enable support for 128-bit floats.
+# UNSUPPORTED
+# -----------
+# Currently unsupported features.
+# Enable support for 128-bit floats. Unsupported and unlikely to ever be.
+#   https://github.com/Alexhuszagh/rust-lexical/issues/46
 f128 = ["lexical-core/f128"]
 
 [package.metadata.docs.rs]

--- a/lexical/src/lib.rs
+++ b/lexical/src/lib.rs
@@ -301,6 +301,26 @@
     clippy::semicolon_inside_block,
 )]
 
+// Ensure our features are properly enabled. This means no parse without
+// parse support, etc.
+#[cfg(all(feature = "parse", not(any(feature = "parse-integers", feature = "parse-floats"))))]
+compile_error!(
+    "Do not use the `parse` feature directly. Use `parse-integers` and/or `parse-floats` instead."
+);
+
+#[cfg(all(feature = "write", not(any(feature = "write-integers", feature = "write-floats"))))]
+compile_error!(
+    "Do not use the `write` feature directly. Use `write-integers` and/or `write-floats` instead."
+);
+
+#[cfg(all(feature = "integers", not(any(feature = "write-integers", feature = "parse-integers"))))]
+compile_error!("Do not use the `integers` feature directly. Use `write-integers` and/or `parse-integers` instead.");
+
+#[cfg(all(feature = "floats", not(any(feature = "write-floats", feature = "parse-floats"))))]
+compile_error!(
+    "Do not use the `floats` feature directly. Use `write-floats` and/or `parse-floats` instead."
+);
+
 // Need an allocator for String/Vec.
 #[cfg(feature = "write")]
 #[macro_use(vec)]


### PR DESCRIPTION
This had a bug where it always used the digit-count, which is the base-10 digits, rather than the correct radix counts, when writing floats. This patches those bugs.

It also ensures that `parse`, `write`, etc. are used correctly with compiler feature detection and errors.