### PR TITLE
Remove LTO for OSS-Fuzz Dependencies

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,7 +34,7 @@ default-features = false
 features = []
 
 [dependencies]
-libfuzzer-sys = "0.2.0"
+libfuzzer-sys = "0.4.7"
 
 [features]
 std = [
@@ -74,7 +74,6 @@ compact = [
 opt-level = 3
 debug = false
 debug-assertions = false
-lto = true
 
 [[bin]]
 name = "parse-integer-i8"

--- a/fuzz/fuzz_targets/parse-float-f32.rs
+++ b/fuzz/fuzz_targets/parse-float-f32.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_float::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-float-f64.rs
+++ b/fuzz/fuzz_targets/parse-float-f64.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_float::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-i128.rs
+++ b/fuzz/fuzz_targets/parse-integer-i128.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-i16.rs
+++ b/fuzz/fuzz_targets/parse-integer-i16.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-i32.rs
+++ b/fuzz/fuzz_targets/parse-integer-i32.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-i64.rs
+++ b/fuzz/fuzz_targets/parse-integer-i64.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-i8.rs
+++ b/fuzz/fuzz_targets/parse-integer-i8.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-isize.rs
+++ b/fuzz/fuzz_targets/parse-integer-isize.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-u128.rs
+++ b/fuzz/fuzz_targets/parse-integer-u128.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-u16.rs
+++ b/fuzz/fuzz_targets/parse-integer-u16.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-u32.rs
+++ b/fuzz/fuzz_targets/parse-integer-u32.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-u64.rs
+++ b/fuzz/fuzz_targets/parse-integer-u64.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-u8.rs
+++ b/fuzz/fuzz_targets/parse-integer-u8.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse-integer-usize.rs
+++ b/fuzz/fuzz_targets/parse-integer-usize.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_parse_integer::FromLexical;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/write-float-f32.rs
+++ b/fuzz/fuzz_targets/write-float-f32.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_float::ToLexical;
 

--- a/fuzz/fuzz_targets/write-float-f64.rs
+++ b/fuzz/fuzz_targets/write-float-f64.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_float::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-i128.rs
+++ b/fuzz/fuzz_targets/write-integer-i128.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-i16.rs
+++ b/fuzz/fuzz_targets/write-integer-i16.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-i32.rs
+++ b/fuzz/fuzz_targets/write-integer-i32.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-i64.rs
+++ b/fuzz/fuzz_targets/write-integer-i64.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-i8.rs
+++ b/fuzz/fuzz_targets/write-integer-i8.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-isize.rs
+++ b/fuzz/fuzz_targets/write-integer-isize.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-u128.rs
+++ b/fuzz/fuzz_targets/write-integer-u128.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-u16.rs
+++ b/fuzz/fuzz_targets/write-integer-u16.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-u32.rs
+++ b/fuzz/fuzz_targets/write-integer-u32.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-u64.rs
+++ b/fuzz/fuzz_targets/write-integer-u64.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-u8.rs
+++ b/fuzz/fuzz_targets/write-integer-u8.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/fuzz/fuzz_targets/write-integer-usize.rs
+++ b/fuzz/fuzz_targets/write-integer-usize.rs
@@ -1,6 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 use lexical_util::constants::BUFFER_SIZE;
 use lexical_write_integer::ToLexical;
 

--- a/lexical-benchmark/algorithm/division.rs
+++ b/lexical-benchmark/algorithm/division.rs
@@ -36,6 +36,10 @@ fn fast_div(v: u32) -> (u32, u32) {
     let max_precision = 14;
     let additional_precision = 5;
 
+    // FIXME: Determine if this produces as efficient code with the `div_ceil`
+    // method.
+    // reason="performance must be guaranteed as well as correctness"
+    #[allow(clippy::manual_div_ceil)]
     let left_end = ((1 << (max_precision + additional_precision)) + divisor - 1) / divisor;
     let quotient = (v.wrapping_mul(left_end)) >> (max_precision + additional_precision);
     let remainder = v - divisor * quotient;

--- a/lexical-parse-float/Cargo.toml
+++ b/lexical-parse-float/Cargo.toml
@@ -37,7 +37,7 @@ static_assertions = "1"
 #  There's an issue in quickcheck due to an infinitely repeating shrinker.
 #  Issue:   https://github.com/BurntSushi/quickcheck/issues/295
 #  Fix:     https://github.com/BurntSushi/quickcheck/pull/296
-quickcheck = { git = "https://github.com/neithernut/quickcheck/", branch = "i32min-shrink-bound" }
+quickcheck = { git = "https://github.com/Alexhuszagh/quickcheck/", branch = "i32min-shrink-bound-legacy" }
 proptest = ">=1.5.0"
 
 [features]

--- a/lexical-parse-float/src/bigint.rs
+++ b/lexical-parse-float/src/bigint.rs
@@ -758,7 +758,7 @@ impl<const SIZE: usize> Default for StackVec<SIZE> {
     }
 }
 
-/// REVERSE VIEW
+// REVERSE VIEW
 
 /// Reverse, immutable view of a sequence.
 pub struct ReverseView<'a, T: 'a> {
@@ -1202,7 +1202,7 @@ pub fn large_add<const SIZE: usize>(x: &mut StackVec<SIZE>, y: &[Limb]) -> Optio
 /// ```
 ///
 /// We get the following results:
-
+///
 /// ```text
 /// mul/small:long          time:   [220.23 ns 221.47 ns 222.81 ns]
 /// Found 4 outliers among 100 measurements (4.00%)

--- a/lexical-parse-integer/Cargo.toml
+++ b/lexical-parse-integer/Cargo.toml
@@ -31,7 +31,7 @@ features = ["parse-integers"]
 #  There's an issue in quickcheck due to an infinitely repeating shrinker.
 #  Issue:   https://github.com/BurntSushi/quickcheck/issues/295
 #  Fix:     https://github.com/BurntSushi/quickcheck/pull/296
-quickcheck = { git = "https://github.com/neithernut/quickcheck/", branch = "i32min-shrink-bound" }
+quickcheck = { git = "https://github.com/Alexhuszagh/quickcheck/", branch = "i32min-shrink-bound-legacy" }
 proptest = ">=1.5.0"
 
 [features]

--- a/lexical-util/Cargo.toml
+++ b/lexical-util/Cargo.toml
@@ -25,7 +25,7 @@ static_assertions = "1"
 #  There's an issue in quickcheck due to an infinitely repeating shrinker.
 #  Issue:   https://github.com/BurntSushi/quickcheck/issues/295
 #  Fix:     https://github.com/BurntSushi/quickcheck/pull/296
-quickcheck = { git = "https://github.com/neithernut/quickcheck/", branch = "i32min-shrink-bound" }
+quickcheck = { git = "https://github.com/Alexhuszagh/quickcheck/", branch = "i32min-shrink-bound-legacy" }
 proptest = ">=1.5.0"
 
 # FEATURES

--- a/lexical-write-float/Cargo.toml
+++ b/lexical-write-float/Cargo.toml
@@ -38,7 +38,7 @@ approx = "0.5.0"
 #  There's an issue in quickcheck due to an infinitely repeating shrinker.
 #  Issue:   https://github.com/BurntSushi/quickcheck/issues/295
 #  Fix:     https://github.com/BurntSushi/quickcheck/pull/296
-quickcheck = { git = "https://github.com/neithernut/quickcheck/", branch = "i32min-shrink-bound" }
+quickcheck = { git = "https://github.com/Alexhuszagh/quickcheck/", branch = "i32min-shrink-bound-legacy" }
 proptest = ">=1.5.0"
 fraction = "0.15.0"
 

--- a/lexical-write-integer/Cargo.toml
+++ b/lexical-write-integer/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [dependencies]
-static_assertions = "1"
+static_assertions = "1.1.0"
 
 [dependencies.lexical-util]
 version = "1.0.3"
@@ -31,7 +31,7 @@ features = ["write-integers"]
 #  There's an issue in quickcheck due to an infinitely repeating shrinker.
 #  Issue:   https://github.com/BurntSushi/quickcheck/issues/295
 #  Fix:     https://github.com/BurntSushi/quickcheck/pull/296
-quickcheck = { git = "https://github.com/neithernut/quickcheck/", branch = "i32min-shrink-bound" }
+quickcheck = { git = "https://github.com/Alexhuszagh/quickcheck/", branch = "i32min-shrink-bound-legacy" }
 proptest = ">=1.5.0"
 
 [features]


### PR DESCRIPTION
Update fuzzing dependencies and logic.

Gets rid of LTO, which has a bug with `__sancov_gen_` being an undefined symbol. Also, this updates the macro use to directly import the symbols to reflect more modern Rust design.

Closes #164 