### PR TITLE
Use an older nightly toolchain to fix spurious memleak issues.

### DIFF
--- a/.github/workflows/Valgrind.yml
+++ b/.github/workflows/Valgrind.yml
@@ -14,9 +14,14 @@ jobs:
       - name: Install latest nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: nightly
+            # NOTE: For whatever reason, there's a memory leak for recent
+            # versions if we don't FULLY qualify the toolchain version.
+            # This seems to have happened between 2024-09-27 and 2024-10-03.
+            # But, since it requires an unqualified nightly name, it's
+            # impossible to bisect.
+            toolchain: nightly-2024-09-27
       - run: sudo apt-get update
       - run: sudo apt-get install valgrind
-      - run: cargo +nightly install cargo-valgrind
-      - run: cargo +nightly valgrind test --release
-      - run: cargo +nightly valgrind test --all-features --release
+      - run: cargo +nightly-2024-09-27 install cargo-valgrind
+      - run: cargo +nightly-2024-09-27 valgrind test --release
+      - run: cargo +nightly-2024-09-27 valgrind test --all-features --release


### PR DESCRIPTION
After the test cleanup, the test result is ok with no memory leaks in the code, but the cleanup incorrectly reports a memory leak. Since no tests are run, this is not an error in lexical:

```bash
    Finished `release` profile [optimized] target(s) in 3m 40s
     Running unittests src/lib.rs (target/release/deps/lexical-cfe9a35d657545f8)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

       Error leaked 56 B in 1 block
        Info stack trace (user code at the bottom)
             at malloc
             at main
     Summary Leaked 56 B total (0 other errors)
error: test failed, to rerun pass `-p lexical --lib`

Caused by:
  process didn't exit successfully: `/home/runner/.cargo/bin/cargo-valgrind /home/runner/work/rust-lexical/rust-lexical/target/release/deps/lexical-cfe9a35d657545f8` (exit status: 127)
note: test exited abnormally; to see the full output pass --nocapture to the harness.
```