### PR TITLE
Fix Writing Integers with Non-Decimal Radices

### DIFF
--- a/ci/comprehensive.sh
+++ b/ci/comprehensive.sh
@@ -11,6 +11,7 @@ cargo --version
 script_dir=$(dirname "${BASH_SOURCE[0]}")
 script_home=$(realpath "${script_dir}")
 home=$(dirname "${script_home}")
+version="${CARGO_VERSION}"
 cd "${home}"
 
 # Ensure we have all our testing data files
@@ -20,16 +21,16 @@ run_tests() {
     # Test the parse-float correctness tests
     cd "${home}"
     cd lexical-parse-float/etc/correctness
-    cargo run "${@}" --release --bin test-parse-golang
-    cargo run "${@}" --release --bin test-parse-golang --features digit-separator
-    cargo run "${@}" --release --bin test-parse-unittests
+    cargo ${version} run "${@}" --release --bin test-parse-golang
+    cargo ${version} run "${@}" --release --bin test-parse-golang --features digit-separator
+    cargo ${version} run "${@}" --release --bin test-parse-unittests
 
     # Test the write-float correctness tests.
     cd "${home}"
     cd lexical-write-float/etc/correctness
-    cargo run "${@}" --release --bin shorter_interval
-    cargo run "${@}" --release --bin random
-    cargo run "${@}" --release --bin simple_random  -- --iterations 1000000
+    cargo ${version} run "${@}" --release --bin shorter_interval
+    cargo ${version} run "${@}" --release --bin random
+    cargo ${version} run "${@}" --release --bin simple_random  -- --iterations 1000000
 }
 
 run_tests
@@ -41,5 +42,5 @@ if [ ! -z "${EXHAUSTIVE}" ]; then
 # Test the parse-float correctness tests
     cd "${home}"
     cd lexical-parse-float/etc/correctness
-    cargo run "${@}" --release --bin test-parse-random
+    cargo ${version} run "${@}" --release --bin test-parse-random
 fi

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -8,10 +8,11 @@ set -ex
 script_dir=$(dirname "${BASH_SOURCE[0]}")
 script_home=$(realpath "${script_dir}")
 home=$(dirname "${script_home}")
+version="${CARGO_VERSION}"
 cd "${home}"
 
 # Print our cargo version, for debugging.
-cargo --version
+cargo ${version} --version
 
 # Ensure we have all our testing data files
 git submodule update --init

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -107,6 +107,10 @@ test() {
     # NOTE: This tests a regressions, related to #96.
     cargo test --features=format $DOCTESTS
 
+    # Ensure we test radix without the compact feature
+    # See #169
+    cargo test --features=radix,format --release
+
     # this fixes an issue where the lexical and lexical-core tests weren't being run
     cd lexical-core
     cargo test $test_features,format

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -8,10 +8,11 @@ set -ex
 script_dir=$(dirname "${BASH_SOURCE[0]}")
 script_home=$(realpath "${script_dir}")
 home=$(dirname "${script_home}")
+version="${CARGO_VERSION}"
 cd "${home}"
 
 # Print our cargo version, for debugging.
-cargo --version
+cargo ${version} --version
 
 # Ensure we have all our benchmark data files
 git submodule update --init lexical-benchmark/data
@@ -37,7 +38,7 @@ FEATURES=(
 
 check_error() {
     local feature=$1
-    if 2>/dev/null cargo check --no-default-features --features="${feature}" ; then
+    if 2>/dev/null cargo ${version} check --no-default-features --features="${feature}" ; then
         >&2 echo "The feature ${feature} did not error..."
         exit 1
     fi
@@ -52,21 +53,21 @@ check() {
     # Need to test a few permutations just to ensure everything compiles.
     for features in "${FEATURES[@]}"; do
         check_features="$DEFAULT_FEATURES --features=$REQUIRED_FEATURES,$features"
-        cargo check --tests $check_features
+        cargo ${version} check --tests $check_features
     done
 
     # Check each of our sub-crates compiles.
     cd lexical-parse-float
-    cargo check --tests
+    cargo ${version} check --tests
 
     cd ../lexical-parse-integer
-    cargo check --tests
+    cargo ${version} check --tests
 
     cd ../lexical-write-float
-    cargo check --tests
+    cargo ${version} check --tests
 
     cd ../lexical-write-integer
-    cargo check --tests
+    cargo ${version} check --tests
 
     # ensure our partial features aren't allowed, as are unsupported features
     cd ../lexical-core
@@ -86,8 +87,8 @@ check() {
 # Build target.
 build() {
     build_features="$DEFAULT_FEATURES --features=$REQUIRED_FEATURES"
-    cargo build $build_features
-    cargo build $build_features --release
+    cargo ${version} build $build_features
+    cargo ${version} build $build_features --release
 }
 
 # Test target.
@@ -101,28 +102,28 @@ test() {
 
     # Default tests.
     test_features="$DEFAULT_FEATURES --features=$REQUIRED_FEATURES"
-    cargo test $test_features $DOCTESTS
-    cargo test $test_features $DOCTESTS --release
-    cargo test --features=radix,format,compact $DOCTESTS --release
+    cargo ${version} test $test_features $DOCTESTS
+    cargo ${version} test $test_features $DOCTESTS --release
+    cargo ${version} test --features=radix,format,compact $DOCTESTS --release
     # NOTE: This tests a regressions, related to #96.
-    cargo test --features=format $DOCTESTS
+    cargo ${version} test --features=format $DOCTESTS
 
     # Ensure we test radix without the compact feature
     # See #169
-    cargo test --features=radix,format --release
+    cargo ${version} test --features=radix,format --release
 
     # this fixes an issue where the lexical and lexical-core tests weren't being run
     cd lexical-core
-    cargo test $test_features,format
-    cargo test $test_features,radix
-    cargo test $test_features,format,radix
+    cargo ${version} test $test_features,format
+    cargo ${version} test $test_features,radix
+    cargo ${version} test $test_features,format,radix
     cd ..
 
     # this fixes an issue where the lexical and lexical-core tests weren't being run
     cd lexical
-    cargo test $test_features,format
-    cargo test $test_features,radix
-    cargo test $test_features,format,radix
+    cargo ${version} test $test_features,format
+    cargo ${version} test $test_features,radix
+    cargo ${version} test $test_features,format,radix
     cd ..
 }
 
@@ -144,7 +145,7 @@ bench() {
 
     cd lexical-benchmark
     bench_features="$DEFAULT_FEATURES --features=$REQUIRED_FEATURES"
-    cargo test $bench_features --bench '*'
+    cargo ${version} test $bench_features --bench '*'
     cd ..
 }
 

--- a/lexical-write-float/src/algorithm.rs
+++ b/lexical-write-float/src/algorithm.rs
@@ -32,7 +32,7 @@ use lexical_util::bf16::bf16;
 use lexical_util::f16::f16;
 use lexical_util::format::{NumberFormat, STANDARD};
 use lexical_util::num::{AsPrimitive, Float};
-use lexical_write_integer::decimal::DigitCount;
+use lexical_write_integer::decimal::DecimalCount;
 use lexical_write_integer::write::WriteInteger;
 
 use crate::float::{ExtendedFloat80, RawFloat};
@@ -1218,7 +1218,7 @@ impl DragonboxFloat for f32 {
     #[inline(always)]
     fn digit_count(mantissa: u64) -> usize {
         debug_assert!(mantissa <= u32::MAX as u64);
-        (mantissa as u32).digit_count()
+        (mantissa as u32).decimal_count()
     }
 
     #[inline(always)]
@@ -1328,7 +1328,7 @@ impl DragonboxFloat for f64 {
 
     #[inline(always)]
     fn digit_count(mantissa: u64) -> usize {
-        mantissa.digit_count()
+        mantissa.decimal_count()
     }
 
     #[inline(always)]

--- a/lexical-write-float/src/algorithm.rs
+++ b/lexical-write-float/src/algorithm.rs
@@ -761,7 +761,7 @@ pub fn compute_right_closed_directed<F: RawFloat>(float: F, shorter: bool) -> Ex
 #[allow(clippy::branches_sharing_code)] // reason="could differentiate later"
 pub fn write_digits_u32(bytes: &mut [u8], mantissa: u32) -> usize {
     debug_assert!(bytes.len() >= 10);
-    mantissa.write_mantissa::<u32, { STANDARD }>(bytes)
+    mantissa.write_mantissa::<{ STANDARD }>(bytes)
 }
 
 /// Write the significant digits, when the significant digits cannot fit in a
@@ -774,7 +774,7 @@ pub fn write_digits_u32(bytes: &mut [u8], mantissa: u32) -> usize {
 #[allow(clippy::branches_sharing_code)] // reason="could differentiate later"
 pub fn write_digits_u64(bytes: &mut [u8], mantissa: u64) -> usize {
     debug_assert!(bytes.len() >= 20);
-    mantissa.write_mantissa::<u64, { STANDARD }>(bytes)
+    mantissa.write_mantissa::<{ STANDARD }>(bytes)
 }
 
 // EXTENDED

--- a/lexical-write-float/src/binary.rs
+++ b/lexical-write-float/src/binary.rs
@@ -135,7 +135,7 @@ where
     let shl = calculate_shl(exp, bits_per_digit);
     let value = mantissa << shl;
 
-    let count = value.write_mantissa::<M, FORMAT>(&mut bytes[1..]);
+    let count = value.write_mantissa::<FORMAT>(&mut bytes[1..]);
     bytes[0] = bytes[1];
     bytes[1] = decimal_point;
     let zeros = rtrim_char_count(&bytes[2..count + 1], b'0');
@@ -221,7 +221,7 @@ where
 
     // Won't panic, if the buffer is large enough to hold the significant
     // digits.
-    let count = value.write_mantissa::<M, FORMAT>(&mut bytes[cursor..]);
+    let count = value.write_mantissa::<FORMAT>(&mut bytes[cursor..]);
     let zeros = rtrim_char_count(&bytes[cursor..cursor + count], b'0');
     let digit_count = count - zeros;
     cursor += digit_count;
@@ -267,7 +267,7 @@ where
     let shl = calculate_shl(exp, bits_per_digit);
     let value = mantissa << shl;
 
-    let count = value.write_mantissa::<M, FORMAT>(bytes);
+    let count = value.write_mantissa::<FORMAT>(bytes);
     let zeros = rtrim_char_count(&bytes[..count], b'0');
     let mut digit_count = count - zeros;
 

--- a/lexical-write-float/src/hex.rs
+++ b/lexical-write-float/src/hex.rs
@@ -163,7 +163,7 @@ where
     let shl = calculate_shl(exp, bits_per_digit);
     let value = mantissa << shl;
 
-    let count = value.write_mantissa::<M, FORMAT>(&mut bytes[1..]);
+    let count = value.write_mantissa::<FORMAT>(&mut bytes[1..]);
     bytes[0] = bytes[1];
     bytes[1] = decimal_point;
     let zeros = rtrim_char_count(&bytes[2..count + 1], b'0');

--- a/lexical-write-float/src/shared.rs
+++ b/lexical-write-float/src/shared.rs
@@ -139,7 +139,7 @@ pub fn write_exponent<const FORMAT: u128>(
     bytes[*cursor] = exponent_character;
     *cursor += 1;
     let positive_exp: u32 = write_exponent_sign::<FORMAT>(bytes, cursor, exp);
-    *cursor += positive_exp.write_exponent::<u32, FORMAT>(&mut bytes[*cursor..]);
+    *cursor += positive_exp.write_exponent::<FORMAT>(&mut bytes[*cursor..]);
 }
 
 /// Detect the notation to use for the float formatter and call the appropriate

--- a/lexical-write-integer/Cargo.toml
+++ b/lexical-write-integer/Cargo.toml
@@ -34,6 +34,7 @@ features = ["write-integers"]
 #  Fix:     https://github.com/BurntSushi/quickcheck/pull/296
 quickcheck = { git = "https://github.com/Alexhuszagh/quickcheck/", branch = "i32min-shrink-bound-legacy" }
 proptest = ">=1.5.0"
+rustversion = ">=1.0.18"
 
 [features]
 default = ["std"]

--- a/lexical-write-integer/src/algorithm.rs
+++ b/lexical-write-integer/src/algorithm.rs
@@ -143,7 +143,8 @@ unsafe fn write_digits<T: UnsignedInteger>(
         // SAFETY: this is always safe, since `value < radix`, so it must be < 36.
         write_digit!(buffer, index, r);
     } else {
-        let r = usize::as_cast(T::TWO * value);
+        // NOTE: If this is a `u8`, we need to first widen the type.
+        let r = usize::as_cast(T::TWO) * usize::as_cast(value);
         // SAFETY: this is always safe, since the table is `2*radix^2`, and
         // the value must `<= radix^2`, so rem must be in the range
         // `[0, 2*radix^2-1)`.
@@ -210,8 +211,6 @@ pub fn algorithm<T>(value: T, radix: u32, table: &[u8], buffer: &mut [u8]) -> us
 where
     T: UnsignedInteger + DigitCount,
 {
-    // This is so that `radix^4` does not overflow, since `36^4` overflows a u16.
-    assert!(T::BITS >= 32, "Must have at least 32 bits in the input.");
     // NOTE: These checks should be resolved at compile time, so
     // they're unlikely to add any performance overhead.
     assert!((2..=36).contains(&radix), "radix must be >= 2 and <= 36");

--- a/lexical-write-integer/src/compact.rs
+++ b/lexical-write-integer/src/compact.rs
@@ -11,6 +11,24 @@ use lexical_util::constants::FormattedSize;
 use lexical_util::digit::digit_to_char;
 use lexical_util::num::{AsCast, UnsignedInteger};
 
+// NOTE: Testing our algorithms can be done effectively as:
+//  table = [
+//      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
+//      'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+//      'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+//  ]
+//  def to_string(value, radix):
+//      result = ''
+//      while value >= radix:
+//          r = value % radix
+//          value //= radix
+//          result = table[int(r)] + result
+//
+//      r = value % radix
+//      result = table[int(r)] + result
+//
+//      return result
+
 /// Write integer to string.
 pub trait Compact: UnsignedInteger + FormattedSize {
     /// Write our integer to string without optimizations.

--- a/lexical-write-integer/src/decimal.rs
+++ b/lexical-write-integer/src/decimal.rs
@@ -251,22 +251,6 @@ pub trait Decimal: DecimalCount {
     fn decimal(self, buffer: &mut [u8]) -> usize;
 }
 
-// Don't implement decimal for small types, where we could have an overflow.
-macro_rules! decimal_unimpl {
-    ($($t:ty)*) => ($(
-        impl Decimal for $t {
-            #[inline(always)]
-            fn decimal(self, _: &mut [u8]) -> usize {
-                // Forces a hard error if we have a logic error in our code.
-                // FIXME: Implement these for small type sizes
-                unimplemented!()
-            }
-        }
-    )*);
-}
-
-decimal_unimpl! { u8 u16 usize }
-
 // Implement decimal for type.
 macro_rules! decimal_impl {
     ($($t:ty)*) => ($(
@@ -279,7 +263,7 @@ macro_rules! decimal_impl {
     )*);
 }
 
-decimal_impl! { u32 u64 }
+decimal_impl! { u8 u16 u32 u64 usize }
 
 impl Decimal for u128 {
     #[inline(always)]

--- a/lexical-write-integer/src/decimal.rs
+++ b/lexical-write-integer/src/decimal.rs
@@ -17,23 +17,8 @@ use lexical_util::format::{RADIX, RADIX_SHIFT, STANDARD};
 use lexical_util::num::UnsignedInteger;
 
 use crate::algorithm::{algorithm, algorithm_u128};
+use crate::digit_count::fast_log2;
 use crate::table::DIGIT_TO_BASE10_SQUARED;
-
-/// Fast integral log2.
-///
-/// This is fairly trivial to explain, since the log2 is related to the
-/// number of bits in the value. Therefore, it has to be related to
-/// `T::BITS - ctlz(x)`. For example, `log2(2) == 1`, and `log2(1) == 0`,
-/// and `log2(3) == 1`. Therefore, we must take the log of an odd number,
-/// and subtract one.
-///
-/// This algorithm is described in detail in "Computing the number of digits
-/// of an integer quickly", available
-/// [here](https://lemire.me/blog/2021/05/28/computing-the-number-of-digits-of-an-integer-quickly/).
-#[inline(always)]
-pub fn fast_log2<T: UnsignedInteger>(x: T) -> usize {
-    T::BITS - 1 - (x | T::ONE).leading_zeros() as usize
-}
 
 /// Calculate the fast, integral log10 of a value.
 ///
@@ -125,35 +110,48 @@ pub fn fallback_digit_count<T: UnsignedInteger>(x: T, table: &[T]) -> usize {
     log10 + shift_up as usize + 1
 }
 
-/// Quickly calculate the number of digits in a type.
-pub trait DigitCount: UnsignedInteger {
+/// Quickly calculate the number of decimal digits in a type.
+///
+/// # Safety
+///
+/// Safe as long as `digit_count` returns at least the number of
+/// digits that would be written by the integer. If the value is
+/// too small, then the buffer might underflow, causing out-of-bounds
+/// read/writes.
+pub unsafe trait DecimalCount: UnsignedInteger {
     /// Get the number of digits in a value.
-    fn digit_count(self) -> usize;
+    fn decimal_count(self) -> usize;
 }
 
-macro_rules! digit_count_unimpl {
-    ($($t:ty)*) => ($(
-        impl DigitCount for $t {
-            #[inline(always)]
-            fn digit_count(self) -> usize {
-                unimplemented!()
-            }
-        }
-    )*)
-}
-
-digit_count_unimpl! { u8 u16 usize }
-
-impl DigitCount for u32 {
+// SAFETY: Safe since `fast_digit_count` is always correct for `<= u32::MAX`.
+unsafe impl DecimalCount for u8 {
     #[inline(always)]
-    fn digit_count(self) -> usize {
+    fn decimal_count(self) -> usize {
+        fast_digit_count(self as u32)
+    }
+}
+
+// SAFETY: Safe since `fast_digit_count` is always correct for `<= u32::MAX`.
+unsafe impl DecimalCount for u16 {
+    #[inline(always)]
+    fn decimal_count(self) -> usize {
+        fast_digit_count(self as u32)
+    }
+}
+
+// SAFETY: Safe since `fast_digit_count` is always correct for `<= u32::MAX`.
+unsafe impl DecimalCount for u32 {
+    #[inline(always)]
+    fn decimal_count(self) -> usize {
         fast_digit_count(self)
     }
 }
 
-impl DigitCount for u64 {
+// SAFETY: Safe since `fallback_digit_count` is valid for the current table,
+// as described in <https://lemire.me/blog/2021/06/03/computing-the-number-of-digits-of-an-integer-even-faster/>
+unsafe impl DecimalCount for u64 {
     #[inline(always)]
-    fn digit_count(self) -> usize {
+    fn decimal_count(self) -> usize {
         const TABLE: [u64; 19] = [
             10,
             100,
@@ -179,9 +177,11 @@ impl DigitCount for u64 {
     }
 }
 
-impl DigitCount for u128 {
+// SAFETY: Safe since `fallback_digit_count` is valid for the current table,
+// as described in <https://lemire.me/blog/2021/06/03/computing-the-number-of-digits-of-an-integer-even-faster/>
+unsafe impl DecimalCount for u128 {
     #[inline(always)]
-    fn digit_count(self) -> usize {
+    fn decimal_count(self) -> usize {
         const TABLE: [u128; 38] = [
             10,
             100,
@@ -226,8 +226,21 @@ impl DigitCount for u128 {
     }
 }
 
+// SAFETY: Safe since it uses the default implementation for the type size.
+unsafe impl DecimalCount for usize {
+    #[inline(always)]
+    fn decimal_count(self) -> usize {
+        match Self::BITS {
+            8 | 16 | 32 => (self as u32).decimal_count(),
+            64 => (self as u64).decimal_count(),
+            128 => (self as u128).decimal_count(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
 /// Write integer to decimal string.
-pub trait Decimal: DigitCount {
+pub trait Decimal: DecimalCount {
     /// # Safety
     ///
     /// Safe as long as buffer is at least [`FORMATTED_SIZE`] elements long,
@@ -245,6 +258,7 @@ macro_rules! decimal_unimpl {
             #[inline(always)]
             fn decimal(self, _: &mut [u8]) -> usize {
                 // Forces a hard error if we have a logic error in our code.
+                // FIXME: Implement these for small type sizes
                 unimplemented!()
             }
         }
@@ -259,9 +273,7 @@ macro_rules! decimal_impl {
         impl Decimal for $t {
             #[inline(always)]
             fn decimal(self, buffer: &mut [u8]) -> usize {
-                let count = self.digit_count();
-                let _ = algorithm(self, 10, &DIGIT_TO_BASE10_SQUARED, buffer, count);
-                count
+                algorithm(self, 10, &DIGIT_TO_BASE10_SQUARED, buffer)
             }
         }
     )*);
@@ -272,13 +284,10 @@ decimal_impl! { u32 u64 }
 impl Decimal for u128 {
     #[inline(always)]
     fn decimal(self, buffer: &mut [u8]) -> usize {
-        let count = self.digit_count();
-        let _ = algorithm_u128::<{ STANDARD }, { RADIX }, { RADIX_SHIFT }>(
+        algorithm_u128::<{ STANDARD }, { RADIX }, { RADIX_SHIFT }>(
             self,
             &DIGIT_TO_BASE10_SQUARED,
             buffer,
-            count,
-        );
-        count
+        )
     }
 }

--- a/lexical-write-integer/src/digit_count.rs
+++ b/lexical-write-integer/src/digit_count.rs
@@ -1,0 +1,79 @@
+//! Get the number of digits for an integer formatted for a radix.
+//!
+//! This will always accurately calculate the number of digits for
+//! a given radix, using optimizations for cases with a power-of-two
+//! and decimal numbers.
+
+#![cfg(not(feature = "compact"))]
+#![doc(hidden)]
+
+use lexical_util::num::UnsignedInteger;
+
+use crate::decimal::DecimalCount;
+
+/// Fast integral log2.
+///
+/// This is fairly trivial to explain, since the log2 is related to the
+/// number of bits in the value. Therefore, it has to be related to
+/// `T::BITS - ctlz(x)`. For example, `log2(2) == 1`, and `log2(1) == 0`,
+/// and `log2(3) == 1`. Therefore, we must take the log of an odd number,
+/// and subtract one.
+///
+/// This algorithm is described in detail in "Computing the number of digits
+/// of an integer quickly", available
+/// [here](https://lemire.me/blog/2021/05/28/computing-the-number-of-digits-of-an-integer-quickly/).
+#[inline(always)]
+pub fn fast_log2<T: UnsignedInteger>(x: T) -> usize {
+    T::BITS - 1 - (x | T::ONE).leading_zeros() as usize
+}
+
+/// Quickly calculate the number of digits in a type.
+///
+/// This uses optimizations for powers-of-two and decimal
+/// numbers, which can correctly calculate the number of
+/// values without requiring logs or other expensive
+/// calculations.
+///
+/// # Safety
+///
+/// Safe as long as `digit_count` returns at least the number of
+/// digits that would be written by the integer. If the value is
+/// too small, then the buffer might underflow, causing out-of-bounds
+/// read/writes.
+pub unsafe trait DigitCount: UnsignedInteger + DecimalCount {
+    /// Get the number of digits in a value.
+    #[inline(always)]
+    fn digit_count(self, radix: u32) -> usize {
+        assert!((2..=36).contains(&radix), "radix must be >= 2 and <= 36");
+        match radix {
+            10 => self.decimal_count(),
+            // NOTE: This is currently horribly inefficient and exists just for correctness.
+            // FIXME: Optimize for power-of-two radices
+            // FIXME: Optimize for u128
+            // FIXME: Optimize for non-power-of-two radices.
+            _ => {
+                let radix = Self::from_u32(radix);
+                let mut digits = 1;
+                // NOTE: For radix 10, 0-9 would be 1 digit while 10-99 would be 2 digits,
+                // so this needs to be >=
+                let mut value = self;
+                while value >= radix {
+                    digits += 1;
+                    value /= radix;
+                }
+                digits
+            },
+        }
+    }
+}
+
+// Implement digit counts for all types.
+macro_rules! digit_impl {
+    ($($t:ty)*) => ($(
+        // SAFETY: Safe since it uses the default implementation.
+        unsafe impl DigitCount for $t {
+        }
+    )*);
+}
+
+digit_impl! { u8 u16 usize u32 u64 u128 }

--- a/lexical-write-integer/src/lib.rs
+++ b/lexical-write-integer/src/lib.rs
@@ -152,6 +152,7 @@ mod index;
 pub mod algorithm;
 pub mod compact;
 pub mod decimal;
+pub mod digit_count;
 pub mod options;
 pub mod radix;
 pub mod table;

--- a/lexical-write-integer/src/radix.rs
+++ b/lexical-write-integer/src/radix.rs
@@ -12,7 +12,6 @@
 #![cfg(feature = "power-of-two")]
 #![doc(hidden)]
 
-use lexical_util::algorithm::copy_to_dst;
 use lexical_util::format;
 use lexical_util::num::{Integer, UnsignedInteger};
 
@@ -38,6 +37,7 @@ macro_rules! radix_unimpl {
             #[inline(always)]
             fn radix<const __: u128, const ___: u128, const ____: i32>(self, _: &mut [u8]) -> usize {
                 // Forces a hard error if we have a logic error in our code.
+                // FIXME: Implement these for small type sizes
                 unimplemented!()
             }
         }
@@ -58,11 +58,7 @@ macro_rules! radix_impl {
                 debug_assert!(<Self as Integer>::BITS <= 64);
                 let radix = format::radix_from_flags(FORMAT, MASK, SHIFT);
                 let table = get_table::<FORMAT, MASK, SHIFT>();
-                let mut digits: [u8; 64] = [0u8; 64];
-                let count = digits.len();
-                // SAFETY: Safe since 64 bytes is always enough to hold the digits of a <= 64 bit integer.
-                let index = unsafe { algorithm(self, radix, table, &mut digits, count) };
-                copy_to_dst(buffer, &mut digits[index..])
+                algorithm(self, radix, table, buffer)
             }
         }
     )*);
@@ -77,12 +73,6 @@ impl Radix for u128 {
         buffer: &mut [u8],
     ) -> usize {
         let table = get_table::<FORMAT, MASK, SHIFT>();
-        let mut digits: [u8; 128] = [0u8; 128];
-        let count = digits.len();
-        // SAFETY: Safe since 128 bytes is always enough to hold the digits of a 128 bit
-        // integer.
-        let index =
-            unsafe { algorithm_u128::<FORMAT, MASK, SHIFT>(self, table, &mut digits, count) };
-        copy_to_dst(buffer, &mut digits[index..])
+        algorithm_u128::<FORMAT, MASK, SHIFT>(self, table, buffer)
     }
 }

--- a/lexical-write-integer/src/radix.rs
+++ b/lexical-write-integer/src/radix.rs
@@ -30,22 +30,6 @@ pub trait Radix: UnsignedInteger {
     ) -> usize;
 }
 
-// Don't implement radix for small types, where we could have an overflow.
-macro_rules! radix_unimpl {
-    ($($t:ty)*) => ($(
-        impl Radix for $t {
-            #[inline(always)]
-            fn radix<const __: u128, const ___: u128, const ____: i32>(self, _: &mut [u8]) -> usize {
-                // Forces a hard error if we have a logic error in our code.
-                // FIXME: Implement these for small type sizes
-                unimplemented!()
-            }
-        }
-    )*);
-}
-
-radix_unimpl! { u8 u16 usize }
-
 // Implement radix for type.
 macro_rules! radix_impl {
     ($($t:ty)*) => ($(
@@ -64,7 +48,7 @@ macro_rules! radix_impl {
     )*);
 }
 
-radix_impl! { u32 u64 }
+radix_impl! { u8 u16 u32 u64 usize }
 
 impl Radix for u128 {
     #[inline(always)]

--- a/lexical-write-integer/src/write.rs
+++ b/lexical-write-integer/src/write.rs
@@ -14,17 +14,14 @@ use crate::radix::Radix;
 
 /// Define the implementation to write significant digits.
 macro_rules! write_mantissa {
-    ($($t:tt)+) => (
+    ($($t:tt)+) => {
         /// Internal implementation to write significant digits for float writers.
         #[doc(hidden)]
         #[inline(always)]
-        fn write_mantissa<U, const FORMAT: u128>(self, buffer: &mut [u8]) -> usize
-        where
-            U: $($t)+,
-        {
-            self.write_integer::<U, FORMAT, { format::RADIX }, { format::RADIX_SHIFT }>(buffer)
+        fn write_mantissa<const FORMAT: u128>(self, buffer: &mut [u8]) -> usize {
+            self.write_integer::<FORMAT, { format::RADIX }, { format::RADIX_SHIFT }>(buffer)
         }
-    )
+    };
 }
 
 /// Define the implementation to write exponent digits.
@@ -33,11 +30,9 @@ macro_rules! write_exponent {
         /// Internal implementation to write exponent digits for float writers.
         #[doc(hidden)]
         #[inline(always)]
-        fn write_exponent<U, const FORMAT: u128>(self, buffer: &mut [u8]) -> usize
-        where
-            U: $($t)+,
+        fn write_exponent<const FORMAT: u128>(self, buffer: &mut [u8]) -> usize
         {
-            self.write_integer::<U, FORMAT, { format::EXPONENT_RADIX }, { format::EXPONENT_RADIX_SHIFT }>(buffer)
+            self.write_integer::<FORMAT, { format::EXPONENT_RADIX }, { format::EXPONENT_RADIX_SHIFT }>(buffer)
         }
     )
 }
@@ -53,16 +48,12 @@ pub trait WriteInteger: Compact {
     ///
     /// [`FORMATTED_SIZE`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE
     /// [`FORMATTED_SIZE_DECIMAL`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE_DECIMAL
-    fn write_integer<U, const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
+    fn write_integer<const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
         self,
         buffer: &mut [u8],
-    ) -> usize
-    where
-        U: Compact,
-    {
-        let value = U::as_cast(self);
+    ) -> usize {
         let radix = format::radix_from_flags(FORMAT, MASK, SHIFT);
-        value.compact(radix, buffer)
+        self.compact(radix, buffer)
     }
 
     write_mantissa!(Compact);
@@ -81,15 +72,11 @@ pub trait WriteInteger: Decimal {
     ///
     /// [`FORMATTED_SIZE_DECIMAL`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE_DECIMAL
     #[inline(always)]
-    fn write_integer<U, const __: u128, const ___: u128, const ____: i32>(
+    fn write_integer<const __: u128, const ___: u128, const ____: i32>(
         self,
         buffer: &mut [u8],
-    ) -> usize
-    where
-        U: Decimal,
-    {
-        let value = U::as_cast(self);
-        value.decimal(buffer)
+    ) -> usize {
+        self.decimal(buffer)
     }
 
     write_mantissa!(Decimal);
@@ -109,18 +96,14 @@ pub trait WriteInteger: Decimal + Radix {
     /// [`FORMATTED_SIZE`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE
     /// [`FORMATTED_SIZE_DECIMAL`]: lexical_util::constants::FormattedSize::FORMATTED_SIZE_DECIMAL
     #[inline(always)]
-    fn write_integer<U, const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
+    fn write_integer<const FORMAT: u128, const MASK: u128, const SHIFT: i32>(
         self,
         buffer: &mut [u8],
-    ) -> usize
-    where
-        U: Decimal + Radix,
-    {
-        let value = U::as_cast(self);
+    ) -> usize {
         if format::radix_from_flags(FORMAT, MASK, SHIFT) == 10 {
-            value.decimal(buffer)
+            self.decimal(buffer)
         } else {
-            value.radix::<FORMAT, MASK, SHIFT>(buffer)
+            self.radix::<FORMAT, MASK, SHIFT>(buffer)
         }
     }
 

--- a/lexical-write-integer/tests/decimal_tests.rs
+++ b/lexical-write-integer/tests/decimal_tests.rs
@@ -3,22 +3,7 @@
 mod util;
 
 use lexical_util::num::UnsignedInteger;
-use lexical_write_integer::decimal::{self, Decimal, DigitCount};
-
-#[test]
-fn fast_log2_test() {
-    // Check the first, even if illogical case works.
-    assert_eq!(decimal::fast_log2(0u32), 0);
-    assert_eq!(decimal::fast_log2(1u32), 0);
-    assert_eq!(decimal::fast_log2(2u32), 1);
-    assert_eq!(decimal::fast_log2(3u32), 1);
-
-    assert_eq!(decimal::fast_log2((1u32 << 16) - 1), 15);
-    assert_eq!(decimal::fast_log2(1u32 << 16), 16);
-    assert_eq!(decimal::fast_log2((1u32 << 16) + 1), 16);
-
-    assert_eq!(decimal::fast_log2(u32::MAX), 31);
-}
+use lexical_write_integer::decimal::{self, Decimal, DecimalCount};
 
 #[test]
 fn fast_log10_test() {
@@ -32,39 +17,39 @@ fn fast_log10_test() {
 }
 
 #[test]
-fn u32_digit_count_test() {
-    assert_eq!(u32::digit_count(0), 1);
-    assert_eq!(u32::digit_count(1), 1);
-    assert_eq!(u32::digit_count(9), 1);
-    assert_eq!(u32::digit_count(10), 2);
-    assert_eq!(u32::digit_count(11), 2);
+fn u32_decimal_count_test() {
+    assert_eq!(u32::decimal_count(0), 1);
+    assert_eq!(u32::decimal_count(1), 1);
+    assert_eq!(u32::decimal_count(9), 1);
+    assert_eq!(u32::decimal_count(10), 2);
+    assert_eq!(u32::decimal_count(11), 2);
 
-    assert_eq!(u32::digit_count((1 << 16) - 1), 5);
-    assert_eq!(u32::digit_count(1 << 16), 5);
-    assert_eq!(u32::digit_count((1 << 16) + 1), 5);
+    assert_eq!(u32::decimal_count((1 << 16) - 1), 5);
+    assert_eq!(u32::decimal_count(1 << 16), 5);
+    assert_eq!(u32::decimal_count((1 << 16) + 1), 5);
 
-    assert_eq!(u32::digit_count(u32::MAX), 10);
+    assert_eq!(u32::decimal_count(u32::MAX), 10);
 }
 
 #[test]
-fn u64_digit_count_test() {
-    assert_eq!(u64::digit_count(0), 1);
-    assert_eq!(u64::digit_count(1), 1);
-    assert_eq!(u64::digit_count(9), 1);
-    assert_eq!(u64::digit_count(10), 2);
-    assert_eq!(u64::digit_count(11), 2);
+fn u64_decimal_count_test() {
+    assert_eq!(u64::decimal_count(0), 1);
+    assert_eq!(u64::decimal_count(1), 1);
+    assert_eq!(u64::decimal_count(9), 1);
+    assert_eq!(u64::decimal_count(10), 2);
+    assert_eq!(u64::decimal_count(11), 2);
 
-    assert_eq!(u64::digit_count((1 << 16) - 1), 5);
-    assert_eq!(u64::digit_count(1 << 16), 5);
-    assert_eq!(u64::digit_count((1 << 16) + 1), 5);
+    assert_eq!(u64::decimal_count((1 << 16) - 1), 5);
+    assert_eq!(u64::decimal_count(1 << 16), 5);
+    assert_eq!(u64::decimal_count((1 << 16) + 1), 5);
 
-    assert_eq!(u64::digit_count(u32::MAX as u64), 10);
-    assert_eq!(u64::digit_count(u64::MAX), 20);
+    assert_eq!(u64::decimal_count(u32::MAX as u64), 10);
+    assert_eq!(u64::decimal_count(u64::MAX), 20);
 }
 
 #[test]
-fn u128_digit_count_test() {
-    assert_eq!(u128::digit_count(u128::MAX), 39);
+fn u128_decimal_count_test() {
+    assert_eq!(u128::decimal_count(u128::MAX), 39);
 }
 
 #[test]
@@ -400,34 +385,21 @@ fn u128toa_test() {
     assert_eq!(&buffer[..39], b"340282366920938463463374607431768211455");
 }
 
-fn slow_log2(x: u32) -> usize {
-    // Slow approach to calculating a log2, using floats.
-    if x == 0 {
-        0
-    } else {
-        (x as f64).log2().floor() as usize
-    }
-}
-
 fn slow_digit_count<T: UnsignedInteger>(x: T) -> usize {
     x.to_string().len()
 }
 
 default_quickcheck! {
-    fn fast_log2_quickcheck(x: u32) -> bool {
-        slow_log2(x) == decimal::fast_log2(x)
-    }
-
     fn u32_digit_count_quickcheck(x: u32) -> bool {
-        slow_digit_count(x) == x.digit_count()
+        slow_digit_count(x) == x.decimal_count()
     }
 
     fn u64_digit_count_quickcheck(x: u64) -> bool {
-        slow_digit_count(x) == x.digit_count()
+        slow_digit_count(x) == x.decimal_count()
     }
 
     fn u128_digit_count_quickcheck(x: u128) -> bool {
-        slow_digit_count(x) == x.digit_count()
+        slow_digit_count(x) == x.decimal_count()
     }
 
     fn u32toa_quickcheck(x: u32) -> bool {

--- a/lexical-write-integer/tests/digit_count_tests.rs
+++ b/lexical-write-integer/tests/digit_count_tests.rs
@@ -1,0 +1,35 @@
+#![cfg(not(feature = "compact"))]
+
+mod util;
+
+use lexical_write_integer::digit_count;
+
+#[test]
+fn fast_log2_test() {
+    // Check the first, even if illogical case works.
+    assert_eq!(digit_count::fast_log2(0u32), 0);
+    assert_eq!(digit_count::fast_log2(1u32), 0);
+    assert_eq!(digit_count::fast_log2(2u32), 1);
+    assert_eq!(digit_count::fast_log2(3u32), 1);
+
+    assert_eq!(digit_count::fast_log2((1u32 << 16) - 1), 15);
+    assert_eq!(digit_count::fast_log2(1u32 << 16), 16);
+    assert_eq!(digit_count::fast_log2((1u32 << 16) + 1), 16);
+
+    assert_eq!(digit_count::fast_log2(u32::MAX), 31);
+}
+
+fn slow_log2(x: u32) -> usize {
+    // Slow approach to calculating a log2, using floats.
+    if x == 0 {
+        0
+    } else {
+        (x as f64).log2().floor() as usize
+    }
+}
+
+default_quickcheck! {
+    fn fast_log2_quickcheck(x: u32) -> bool {
+        slow_log2(x) == digit_count::fast_log2(x)
+    }
+}

--- a/lexical-write-integer/tests/digit_count_tests.rs
+++ b/lexical-write-integer/tests/digit_count_tests.rs
@@ -2,7 +2,11 @@
 
 mod util;
 
-use lexical_write_integer::digit_count;
+use lexical_write_integer::decimal::DecimalCount;
+use lexical_write_integer::digit_count::{self, DigitCount};
+use proptest::prelude::*;
+
+use crate::util::default_proptest_config;
 
 #[test]
 fn fast_log2_test() {
@@ -28,8 +32,183 @@ fn slow_log2(x: u32) -> usize {
     }
 }
 
+#[test]
+fn base10_count_test() {
+    assert_eq!(1, 0u32.digit_count(10));
+    assert_eq!(1, 9u32.digit_count(10));
+    assert_eq!(2, 10u32.digit_count(10));
+    assert_eq!(2, 11u32.digit_count(10));
+    assert_eq!(2, 99u32.digit_count(10));
+    assert_eq!(3, 100u32.digit_count(10));
+    assert_eq!(3, 101u32.digit_count(10));
+}
+
+#[test]
+fn base2_count_test() {
+    assert_eq!(1, 0u32.digit_count(2));
+    assert_eq!(1, 1u32.digit_count(2));
+    assert_eq!(2, 2u32.digit_count(2));
+    assert_eq!(2, 3u32.digit_count(2));
+    assert_eq!(3, 4u32.digit_count(2));
+
+    if cfg!(feature = "power-of-two") {
+        for i in 1usize..=127 {
+            let value = 2u128.pow(i as u32);
+            assert_eq!(i + 1, value.digit_count(2));
+            assert_eq!(i + 1, (value + 1).digit_count(2));
+            assert_eq!(i, (value - 1).digit_count(2));
+        }
+    }
+}
+
+#[test]
+fn base4_count_test() {
+    assert_eq!(1, 0u32.digit_count(4));
+    assert_eq!(1, 1u32.digit_count(4));
+    assert_eq!(1, 3u32.digit_count(4));
+    assert_eq!(2, 4u32.digit_count(4));
+    assert_eq!(2, 5u32.digit_count(4));
+    assert_eq!(2, 15u32.digit_count(4));
+    assert_eq!(3, 16u32.digit_count(4));
+    assert_eq!(3, 17u32.digit_count(4));
+
+    if cfg!(feature = "power-of-two") {
+        for i in 1usize..=63 {
+            let value = 4u128.pow(i as u32);
+            assert_eq!(i + 1, value.digit_count(4));
+            assert_eq!(i + 1, (value + 1).digit_count(4));
+            assert_eq!(i, (value - 1).digit_count(4));
+
+            let halfway = value + 2u128.pow(i as u32);
+            assert_eq!(i + 1, halfway.digit_count(4));
+            assert_eq!(i + 1, (halfway + 1).digit_count(4));
+            assert_eq!(i + 1, (halfway - 1).digit_count(4));
+        }
+    }
+}
+
+#[test]
+fn base8_count_test() {
+    assert_eq!(1, 0u32.digit_count(8));
+    assert_eq!(1, 1u32.digit_count(8));
+    assert_eq!(1, 7u32.digit_count(8));
+    assert_eq!(2, 8u32.digit_count(8));
+    assert_eq!(2, 9u32.digit_count(8));
+    assert_eq!(2, 63u32.digit_count(8));
+    assert_eq!(3, 64u32.digit_count(8));
+    assert_eq!(3, 65u32.digit_count(8));
+
+    if cfg!(feature = "power-of-two") {
+        for i in 1usize..=31 {
+            let value = 8u128.pow(i as u32);
+            assert_eq!(i + 1, value.digit_count(8));
+            assert_eq!(i + 1, (value + 1).digit_count(8));
+            assert_eq!(i, (value - 1).digit_count(8));
+
+            let halfway = value + 4u128.pow(i as u32);
+            assert_eq!(i + 1, halfway.digit_count(8));
+            assert_eq!(i + 1, (halfway + 1).digit_count(8));
+            assert_eq!(i + 1, (halfway - 1).digit_count(8));
+        }
+    }
+}
+
+#[test]
+fn base16_count_test() {
+    assert_eq!(1, 0u32.digit_count(16));
+    assert_eq!(1, 1u32.digit_count(16));
+    assert_eq!(1, 15u32.digit_count(16));
+    assert_eq!(2, 16u32.digit_count(16));
+    assert_eq!(2, 17u32.digit_count(16));
+    assert_eq!(2, 255u32.digit_count(16));
+    assert_eq!(3, 256u32.digit_count(16));
+    assert_eq!(3, 257u32.digit_count(16));
+
+    if cfg!(feature = "power-of-two") {
+        for i in 1usize..=15 {
+            let value = 16u128.pow(i as u32);
+            assert_eq!(i + 1, value.digit_count(16));
+            assert_eq!(i + 1, (value + 1).digit_count(16));
+            assert_eq!(i, (value - 1).digit_count(16));
+
+            let halfway = value + 8u128.pow(i as u32);
+            assert_eq!(i + 1, halfway.digit_count(16));
+            assert_eq!(i + 1, (halfway + 1).digit_count(16));
+            assert_eq!(i + 1, (halfway - 1).digit_count(16));
+        }
+    }
+}
+
+#[test]
+fn base32_count_test() {
+    assert_eq!(1, 0u32.digit_count(32));
+    assert_eq!(1, 1u32.digit_count(32));
+    assert_eq!(1, 31u32.digit_count(32));
+    assert_eq!(2, 32u32.digit_count(32));
+    assert_eq!(2, 33u32.digit_count(32));
+    assert_eq!(2, 1023u32.digit_count(32));
+    assert_eq!(3, 1024u32.digit_count(32));
+    assert_eq!(3, 1025u32.digit_count(32));
+
+    if cfg!(feature = "power-of-two") {
+        for i in 1usize..=7 {
+            let value = 32u128.pow(i as u32);
+            assert_eq!(i + 1, value.digit_count(32));
+            assert_eq!(i + 1, (value + 1).digit_count(32));
+            assert_eq!(i, (value - 1).digit_count(32));
+
+            let halfway = value + 16u128.pow(i as u32);
+            assert_eq!(i + 1, halfway.digit_count(32));
+            assert_eq!(i + 1, (halfway + 1).digit_count(32));
+            assert_eq!(i + 1, (halfway - 1).digit_count(32));
+        }
+    }
+}
+
 default_quickcheck! {
+    fn decimal_count_quickcheck(x: u32) -> bool {
+        x.digit_count(10) == x.decimal_count()
+    }
+
     fn fast_log2_quickcheck(x: u32) -> bool {
         slow_log2(x) == digit_count::fast_log2(x)
+    }
+}
+
+macro_rules! ilog {
+    ($x:ident, $radix:expr) => {{
+        if $x > 0 {
+            $x.ilog($radix as _) as usize
+        } else {
+            0usize
+        }
+    }};
+}
+
+proptest! {
+    #![proptest_config(default_proptest_config())]
+
+    #[test]
+    fn basen_u64_test(x: u64, radix in 2u32..=36) {
+        prop_assert_eq!(x.digit_count(radix), ilog!(x, radix) + 1);
+    }
+
+    #[test]
+    #[cfg(feature = "radix")]
+    fn basen_u128_test(x: u128, radix in 2u32..=36) {
+        prop_assert_eq!(x.digit_count(radix), ilog!(x, radix) + 1);
+    }
+
+    #[test]
+    #[cfg(all(feature = "power-of-two", not(feature = "radix")))]
+    fn basen_u128_test(x: u128, power in 1u32..=5) {
+        let radix = 2u32.pow(power);
+        prop_assert_eq!(x.digit_count(radix), ilog!(x, radix) + 1);
+    }
+
+    #[test]
+    #[cfg(not(feature = "power-of-two"))]
+    fn basen_u128_test(x: u128) {
+        prop_assert_eq!(x.digit_count(10), ilog!(x, 10) + 1);
     }
 }

--- a/lexical-write-integer/tests/digit_count_tests.rs
+++ b/lexical-write-integer/tests/digit_count_tests.rs
@@ -4,8 +4,10 @@ mod util;
 
 use lexical_write_integer::decimal::DecimalCount;
 use lexical_write_integer::digit_count::{self, DigitCount};
+#[rustversion::since(1.67)]
 use proptest::prelude::*;
 
+#[rustversion::since(1.67)]
 use crate::util::default_proptest_config;
 
 #[test]
@@ -175,6 +177,7 @@ default_quickcheck! {
     }
 }
 
+#[rustversion::since(1.67)]
 macro_rules! ilog {
     ($x:ident, $radix:expr) => {{
         if $x > 0 {
@@ -185,6 +188,7 @@ macro_rules! ilog {
     }};
 }
 
+#[rustversion::since(1.67)]
 proptest! {
     #![proptest_config(default_proptest_config())]
 

--- a/lexical-write-integer/tests/radix_tests.rs
+++ b/lexical-write-integer/tests/radix_tests.rs
@@ -33,7 +33,7 @@ fn u128toa_test() {
     const FORMAT: u128 = from_radix(12);
     let mut buffer = [b'\x00'; BUFFER_SIZE];
     let value = 136551478823710021067381144334863695872u128;
-    let count = value.write_mantissa::<u128, FORMAT>(&mut buffer);
+    let count = value.write_mantissa::<FORMAT>(&mut buffer);
     unsafe {
         let y = u128::from_str_radix(from_utf8_unchecked(&buffer[..count]), 12);
         assert_eq!(y, Ok(value));
@@ -43,7 +43,7 @@ fn u128toa_test() {
 #[cfg(feature = "power-of-two")]
 fn write_integer<T: WriteInteger, const FORMAT: u128>(x: T, actual: &[u8]) {
     let mut buffer = [b'\x00'; BUFFER_SIZE];
-    let count = x.write_mantissa::<T, FORMAT>(&mut buffer);
+    let count = x.write_mantissa::<FORMAT>(&mut buffer);
     assert_eq!(actual.len(), count);
     assert_eq!(actual, &buffer[..count])
 }
@@ -122,14 +122,14 @@ fn issue_169_tests() {
 #[inline(never)]
 fn to_radix_2_9<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &mut [u8]) -> usize {
     match radix {
-        2 => x.write_mantissa::<T, { from_radix(2) }>(buffer),
-        3 => x.write_mantissa::<T, { from_radix(3) }>(buffer),
-        4 => x.write_mantissa::<T, { from_radix(4) }>(buffer),
-        5 => x.write_mantissa::<T, { from_radix(5) }>(buffer),
-        6 => x.write_mantissa::<T, { from_radix(6) }>(buffer),
-        7 => x.write_mantissa::<T, { from_radix(7) }>(buffer),
-        8 => x.write_mantissa::<T, { from_radix(8) }>(buffer),
-        9 => x.write_mantissa::<T, { from_radix(9) }>(buffer),
+        2 => x.write_mantissa::<{ from_radix(2) }>(buffer),
+        3 => x.write_mantissa::<{ from_radix(3) }>(buffer),
+        4 => x.write_mantissa::<{ from_radix(4) }>(buffer),
+        5 => x.write_mantissa::<{ from_radix(5) }>(buffer),
+        6 => x.write_mantissa::<{ from_radix(6) }>(buffer),
+        7 => x.write_mantissa::<{ from_radix(7) }>(buffer),
+        8 => x.write_mantissa::<{ from_radix(8) }>(buffer),
+        9 => x.write_mantissa::<{ from_radix(9) }>(buffer),
         _ => unimplemented!(),
     }
 }
@@ -137,15 +137,15 @@ fn to_radix_2_9<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &mu
 #[inline(never)]
 fn to_radix_10_18<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &mut [u8]) -> usize {
     match radix {
-        10 => x.write_mantissa::<T, { from_radix(10) }>(buffer),
-        11 => x.write_mantissa::<T, { from_radix(11) }>(buffer),
-        12 => x.write_mantissa::<T, { from_radix(12) }>(buffer),
-        13 => x.write_mantissa::<T, { from_radix(13) }>(buffer),
-        14 => x.write_mantissa::<T, { from_radix(14) }>(buffer),
-        15 => x.write_mantissa::<T, { from_radix(15) }>(buffer),
-        16 => x.write_mantissa::<T, { from_radix(16) }>(buffer),
-        17 => x.write_mantissa::<T, { from_radix(17) }>(buffer),
-        18 => x.write_mantissa::<T, { from_radix(18) }>(buffer),
+        10 => x.write_mantissa::<{ from_radix(10) }>(buffer),
+        11 => x.write_mantissa::<{ from_radix(11) }>(buffer),
+        12 => x.write_mantissa::<{ from_radix(12) }>(buffer),
+        13 => x.write_mantissa::<{ from_radix(13) }>(buffer),
+        14 => x.write_mantissa::<{ from_radix(14) }>(buffer),
+        15 => x.write_mantissa::<{ from_radix(15) }>(buffer),
+        16 => x.write_mantissa::<{ from_radix(16) }>(buffer),
+        17 => x.write_mantissa::<{ from_radix(17) }>(buffer),
+        18 => x.write_mantissa::<{ from_radix(18) }>(buffer),
         _ => unimplemented!(),
     }
 }
@@ -153,15 +153,15 @@ fn to_radix_10_18<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &
 #[inline(never)]
 fn to_radix_19_27<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &mut [u8]) -> usize {
     match radix {
-        19 => x.write_mantissa::<T, { from_radix(19) }>(buffer),
-        20 => x.write_mantissa::<T, { from_radix(20) }>(buffer),
-        21 => x.write_mantissa::<T, { from_radix(21) }>(buffer),
-        22 => x.write_mantissa::<T, { from_radix(22) }>(buffer),
-        23 => x.write_mantissa::<T, { from_radix(23) }>(buffer),
-        24 => x.write_mantissa::<T, { from_radix(24) }>(buffer),
-        25 => x.write_mantissa::<T, { from_radix(25) }>(buffer),
-        26 => x.write_mantissa::<T, { from_radix(26) }>(buffer),
-        27 => x.write_mantissa::<T, { from_radix(27) }>(buffer),
+        19 => x.write_mantissa::<{ from_radix(19) }>(buffer),
+        20 => x.write_mantissa::<{ from_radix(20) }>(buffer),
+        21 => x.write_mantissa::<{ from_radix(21) }>(buffer),
+        22 => x.write_mantissa::<{ from_radix(22) }>(buffer),
+        23 => x.write_mantissa::<{ from_radix(23) }>(buffer),
+        24 => x.write_mantissa::<{ from_radix(24) }>(buffer),
+        25 => x.write_mantissa::<{ from_radix(25) }>(buffer),
+        26 => x.write_mantissa::<{ from_radix(26) }>(buffer),
+        27 => x.write_mantissa::<{ from_radix(27) }>(buffer),
         _ => unimplemented!(),
     }
 }
@@ -169,15 +169,15 @@ fn to_radix_19_27<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &
 #[inline(never)]
 fn to_radix_28_36<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &mut [u8]) -> usize {
     match radix {
-        28 => x.write_mantissa::<T, { from_radix(28) }>(buffer),
-        29 => x.write_mantissa::<T, { from_radix(29) }>(buffer),
-        30 => x.write_mantissa::<T, { from_radix(30) }>(buffer),
-        31 => x.write_mantissa::<T, { from_radix(31) }>(buffer),
-        32 => x.write_mantissa::<T, { from_radix(32) }>(buffer),
-        33 => x.write_mantissa::<T, { from_radix(33) }>(buffer),
-        34 => x.write_mantissa::<T, { from_radix(34) }>(buffer),
-        35 => x.write_mantissa::<T, { from_radix(35) }>(buffer),
-        36 => x.write_mantissa::<T, { from_radix(36) }>(buffer),
+        28 => x.write_mantissa::<{ from_radix(28) }>(buffer),
+        29 => x.write_mantissa::<{ from_radix(29) }>(buffer),
+        30 => x.write_mantissa::<{ from_radix(30) }>(buffer),
+        31 => x.write_mantissa::<{ from_radix(31) }>(buffer),
+        32 => x.write_mantissa::<{ from_radix(32) }>(buffer),
+        33 => x.write_mantissa::<{ from_radix(33) }>(buffer),
+        34 => x.write_mantissa::<{ from_radix(34) }>(buffer),
+        35 => x.write_mantissa::<{ from_radix(35) }>(buffer),
+        36 => x.write_mantissa::<{ from_radix(36) }>(buffer),
         _ => unimplemented!(),
     }
 }

--- a/lexical-write-integer/tests/radix_tests.rs
+++ b/lexical-write-integer/tests/radix_tests.rs
@@ -3,13 +3,29 @@
 
 mod util;
 
+use core::num::ParseIntError;
 use core::str::from_utf8_unchecked;
 
-use lexical_util::constants::BUFFER_SIZE;
+use lexical_util::{constants::BUFFER_SIZE, num::UnsignedInteger};
 use lexical_write_integer::write::WriteInteger;
 use proptest::prelude::*;
 
 use crate::util::{default_proptest_config, from_radix};
+
+pub trait FromRadix: Sized {
+    fn from_radix(src: &str, radix: u32) -> Result<Self, ParseIntError>;
+}
+
+macro_rules! impl_from_radix {
+    ($($t:ty)*) => ($(impl FromRadix for $t {
+        #[inline]
+        fn from_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
+            <$t>::from_str_radix(src, radix)
+        }
+    })*)
+}
+
+impl_from_radix! { u32 u64 u128 }
 
 #[test]
 #[cfg(feature = "radix")]
@@ -90,80 +106,97 @@ fn radix_test() {
     write_integer::<u32, { from_radix(36) }>(37u32, b"11");
 }
 
+#[test]
+#[cfg(feature = "radix")]
+fn issue_169_tests() {
+    let value = 213850084767170003246100602438595641344u128;
+    write_integer::<u128, { from_radix(5) }>(
+        value,
+        b"3411233210434101044040414300210231141130323220441010334",
+    );
+}
+
 // We need to trick the algorithm into thinking we're using a const.
-// Useful for proptests, useless everywhere else.
-macro_rules! to_radix {
-    ($t:ident, $x:ident, $radix:ident, $buffer:ident) => {
-        match $radix {
-            2 => $x.write_mantissa::<$t, { from_radix(2) }>(&mut $buffer),
-            3 => $x.write_mantissa::<$t, { from_radix(3) }>(&mut $buffer),
-            4 => $x.write_mantissa::<$t, { from_radix(4) }>(&mut $buffer),
-            5 => $x.write_mantissa::<$t, { from_radix(5) }>(&mut $buffer),
-            6 => $x.write_mantissa::<$t, { from_radix(6) }>(&mut $buffer),
-            7 => $x.write_mantissa::<$t, { from_radix(7) }>(&mut $buffer),
-            8 => $x.write_mantissa::<$t, { from_radix(8) }>(&mut $buffer),
-            9 => $x.write_mantissa::<$t, { from_radix(9) }>(&mut $buffer),
-            10 => $x.write_mantissa::<$t, { from_radix(10) }>(&mut $buffer),
-            11 => $x.write_mantissa::<$t, { from_radix(11) }>(&mut $buffer),
-            12 => $x.write_mantissa::<$t, { from_radix(12) }>(&mut $buffer),
-            13 => $x.write_mantissa::<$t, { from_radix(13) }>(&mut $buffer),
-            14 => $x.write_mantissa::<$t, { from_radix(14) }>(&mut $buffer),
-            15 => $x.write_mantissa::<$t, { from_radix(15) }>(&mut $buffer),
-            16 => $x.write_mantissa::<$t, { from_radix(16) }>(&mut $buffer),
-            17 => $x.write_mantissa::<$t, { from_radix(17) }>(&mut $buffer),
-            18 => $x.write_mantissa::<$t, { from_radix(18) }>(&mut $buffer),
-            19 => $x.write_mantissa::<$t, { from_radix(19) }>(&mut $buffer),
-            20 => $x.write_mantissa::<$t, { from_radix(20) }>(&mut $buffer),
-            21 => $x.write_mantissa::<$t, { from_radix(21) }>(&mut $buffer),
-            22 => $x.write_mantissa::<$t, { from_radix(22) }>(&mut $buffer),
-            23 => $x.write_mantissa::<$t, { from_radix(23) }>(&mut $buffer),
-            24 => $x.write_mantissa::<$t, { from_radix(24) }>(&mut $buffer),
-            25 => $x.write_mantissa::<$t, { from_radix(25) }>(&mut $buffer),
-            26 => $x.write_mantissa::<$t, { from_radix(26) }>(&mut $buffer),
-            27 => $x.write_mantissa::<$t, { from_radix(27) }>(&mut $buffer),
-            28 => $x.write_mantissa::<$t, { from_radix(28) }>(&mut $buffer),
-            29 => $x.write_mantissa::<$t, { from_radix(29) }>(&mut $buffer),
-            30 => $x.write_mantissa::<$t, { from_radix(30) }>(&mut $buffer),
-            31 => $x.write_mantissa::<$t, { from_radix(31) }>(&mut $buffer),
-            32 => $x.write_mantissa::<$t, { from_radix(32) }>(&mut $buffer),
-            33 => $x.write_mantissa::<$t, { from_radix(33) }>(&mut $buffer),
-            34 => $x.write_mantissa::<$t, { from_radix(34) }>(&mut $buffer),
-            35 => $x.write_mantissa::<$t, { from_radix(35) }>(&mut $buffer),
-            36 => $x.write_mantissa::<$t, { from_radix(36) }>(&mut $buffer),
-            _ => unimplemented!(),
-        }
+// NOTE: This needs to be broken down into 4 functions since otherwise
+// we can overflow the stack, so we just never inline for each test.
+#[inline(never)]
+fn to_radix_2_9<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &mut [u8]) -> usize {
+    match radix {
+        2 => x.write_mantissa::<T, { from_radix(2) }>(buffer),
+        3 => x.write_mantissa::<T, { from_radix(3) }>(buffer),
+        4 => x.write_mantissa::<T, { from_radix(4) }>(buffer),
+        5 => x.write_mantissa::<T, { from_radix(5) }>(buffer),
+        6 => x.write_mantissa::<T, { from_radix(6) }>(buffer),
+        7 => x.write_mantissa::<T, { from_radix(7) }>(buffer),
+        8 => x.write_mantissa::<T, { from_radix(8) }>(buffer),
+        9 => x.write_mantissa::<T, { from_radix(9) }>(buffer),
+        _ => unimplemented!(),
+    }
+}
+
+#[inline(never)]
+fn to_radix_10_18<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &mut [u8]) -> usize {
+    match radix {
+        10 => x.write_mantissa::<T, { from_radix(10) }>(buffer),
+        11 => x.write_mantissa::<T, { from_radix(11) }>(buffer),
+        12 => x.write_mantissa::<T, { from_radix(12) }>(buffer),
+        13 => x.write_mantissa::<T, { from_radix(13) }>(buffer),
+        14 => x.write_mantissa::<T, { from_radix(14) }>(buffer),
+        15 => x.write_mantissa::<T, { from_radix(15) }>(buffer),
+        16 => x.write_mantissa::<T, { from_radix(16) }>(buffer),
+        17 => x.write_mantissa::<T, { from_radix(17) }>(buffer),
+        18 => x.write_mantissa::<T, { from_radix(18) }>(buffer),
+        _ => unimplemented!(),
+    }
+}
+
+#[inline(never)]
+fn to_radix_19_27<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &mut [u8]) -> usize {
+    match radix {
+        19 => x.write_mantissa::<T, { from_radix(19) }>(buffer),
+        20 => x.write_mantissa::<T, { from_radix(20) }>(buffer),
+        21 => x.write_mantissa::<T, { from_radix(21) }>(buffer),
+        22 => x.write_mantissa::<T, { from_radix(22) }>(buffer),
+        23 => x.write_mantissa::<T, { from_radix(23) }>(buffer),
+        24 => x.write_mantissa::<T, { from_radix(24) }>(buffer),
+        25 => x.write_mantissa::<T, { from_radix(25) }>(buffer),
+        26 => x.write_mantissa::<T, { from_radix(26) }>(buffer),
+        27 => x.write_mantissa::<T, { from_radix(27) }>(buffer),
+        _ => unimplemented!(),
+    }
+}
+
+#[inline(never)]
+fn to_radix_28_36<T: UnsignedInteger + WriteInteger>(x: T, radix: u32, buffer: &mut [u8]) -> usize {
+    match radix {
+        28 => x.write_mantissa::<T, { from_radix(28) }>(buffer),
+        29 => x.write_mantissa::<T, { from_radix(29) }>(buffer),
+        30 => x.write_mantissa::<T, { from_radix(30) }>(buffer),
+        31 => x.write_mantissa::<T, { from_radix(31) }>(buffer),
+        32 => x.write_mantissa::<T, { from_radix(32) }>(buffer),
+        33 => x.write_mantissa::<T, { from_radix(33) }>(buffer),
+        34 => x.write_mantissa::<T, { from_radix(34) }>(buffer),
+        35 => x.write_mantissa::<T, { from_radix(35) }>(buffer),
+        36 => x.write_mantissa::<T, { from_radix(36) }>(buffer),
+        _ => unimplemented!(),
+    }
+}
+
+#[inline(never)]
+fn mockup<T: UnsignedInteger + WriteInteger + FromRadix>(
+    x: T,
+    radix: u32,
+) -> Result<(), TestCaseError> {
+    let mut buffer = [b'\x00'; BUFFER_SIZE];
+    let count = match radix {
+        2..=9 => to_radix_2_9(x, radix, &mut buffer),
+        10..=18 => to_radix_10_18(x, radix, &mut buffer),
+        19..=27 => to_radix_19_27(x, radix, &mut buffer),
+        28..=36 => to_radix_28_36(x, radix, &mut buffer),
+        _ => unimplemented!(),
     };
-}
-
-fn u32toa_mockup(x: u32, radix: u32) -> Result<(), TestCaseError> {
-    let mut buffer = [b'\x00'; BUFFER_SIZE];
-    unsafe {
-        let count = to_radix!(u32, x, radix, buffer);
-        let y = u32::from_str_radix(from_utf8_unchecked(&buffer[..count]), radix);
-        prop_assert_eq!(y, Ok(x));
-    }
-
-    Ok(())
-}
-
-fn u64toa_mockup(x: u64, radix: u32) -> Result<(), TestCaseError> {
-    let mut buffer = [b'\x00'; BUFFER_SIZE];
-    unsafe {
-        let count = to_radix!(u64, x, radix, buffer);
-        let y = u64::from_str_radix(from_utf8_unchecked(&buffer[..count]), radix);
-        prop_assert_eq!(y, Ok(x));
-    }
-
-    Ok(())
-}
-
-fn u128toa_mockup(x: u128, radix: u32) -> Result<(), TestCaseError> {
-    let mut buffer = [b'\x00'; BUFFER_SIZE];
-    unsafe {
-        let count = to_radix!(u128, x, radix, buffer);
-        let y = u128::from_str_radix(from_utf8_unchecked(&buffer[..count]), radix);
-        prop_assert_eq!(y, Ok(x));
-    }
+    let y = unsafe { T::from_radix(from_utf8_unchecked(&buffer[..count]), radix) };
+    prop_assert_eq!(y, Ok(x));
 
     Ok(())
 }
@@ -175,7 +208,7 @@ proptest! {
     #[cfg_attr(miri, ignore)]
     #[cfg(feature = "radix")]
     fn u32toa_proptest(x: u32, radix in 2u32..=36) {
-        u32toa_mockup(x, radix)?;
+        mockup(x, radix)?;
     }
 
     #[test]
@@ -183,14 +216,14 @@ proptest! {
     #[cfg(not(feature = "radix"))]
     fn u32toa_proptest(x: u32, power in 1u32..=5) {
         let radix = 2u32.pow(power);
-        u32toa_mockup(x, radix)?;
+        mockup(x, radix)?;
     }
 
     #[test]
     #[cfg_attr(miri, ignore)]
     #[cfg(feature = "radix")]
     fn u64toa_proptest(x: u64, radix in 2u32..=36) {
-        u64toa_mockup(x, radix)?;
+        mockup(x, radix)?;
     }
 
     #[test]
@@ -198,14 +231,14 @@ proptest! {
     #[cfg(not(feature = "radix"))]
     fn u64toa_proptest(x: u64, power in 1u32..=5) {
         let radix = 2u32.pow(power);
-        u64toa_mockup(x, radix)?;
+        mockup(x, radix)?;
     }
 
     #[test]
     #[cfg_attr(miri, ignore)]
     #[cfg(feature = "radix")]
     fn u128toa_proptest(x: u128, radix in 2u32..=36) {
-        u128toa_mockup(x, radix)?;
+        mockup(x, radix)?;
     }
 
     #[test]
@@ -213,6 +246,6 @@ proptest! {
     #[cfg(not(feature = "radix"))]
     fn u128toa_proptest(x: u128, power in 1u32..=5) {
         let radix = 2u32.pow(power);
-        u128toa_mockup(x, radix)?;
+        mockup(x, radix)?;
     }
 }


### PR DESCRIPTION
This fixes issues with writing digits with custom radices.

This calculates the digit count prior to writing the digits, so the digits are always written at the front rather than copying the written digits into place. Additional performance enhancements were added for base 2 and base 4 radices.

Closes #169 