### PR TITLE
Add in jeaiii Optimizations for 64-bit Integers

### DIFF
--- a/lexical-write-float/src/algorithm.rs
+++ b/lexical-write-float/src/algorithm.rs
@@ -30,10 +30,9 @@
 use lexical_util::bf16::bf16;
 #[cfg(feature = "f16")]
 use lexical_util::f16::f16;
-use lexical_util::format::{NumberFormat, STANDARD};
+use lexical_util::format::NumberFormat;
 use lexical_util::num::{AsPrimitive, Float};
-use lexical_write_integer::decimal::DecimalCount;
-use lexical_write_integer::write::WriteInteger;
+use lexical_write_integer::decimal::{Decimal, DecimalCount};
 
 use crate::float::{ExtendedFloat80, RawFloat};
 use crate::options::{Options, RoundMode};
@@ -761,7 +760,7 @@ pub fn compute_right_closed_directed<F: RawFloat>(float: F, shorter: bool) -> Ex
 #[allow(clippy::branches_sharing_code)] // reason="could differentiate later"
 pub fn write_digits_u32(bytes: &mut [u8], mantissa: u32) -> usize {
     debug_assert!(bytes.len() >= 10);
-    mantissa.write_mantissa::<{ STANDARD }>(bytes)
+    mantissa.decimal(bytes)
 }
 
 /// Write the significant digits, when the significant digits cannot fit in a
@@ -774,7 +773,7 @@ pub fn write_digits_u32(bytes: &mut [u8], mantissa: u32) -> usize {
 #[allow(clippy::branches_sharing_code)] // reason="could differentiate later"
 pub fn write_digits_u64(bytes: &mut [u8], mantissa: u64) -> usize {
     debug_assert!(bytes.len() >= 20);
-    mantissa.write_mantissa::<{ STANDARD }>(bytes)
+    mantissa.decimal(bytes)
 }
 
 // EXTENDED
@@ -1223,6 +1222,7 @@ impl DragonboxFloat for f32 {
 
     #[inline(always)]
     fn write_digits(bytes: &mut [u8], mantissa: u64) -> usize {
+        // NOTE: These digits are after shifting, so it can be 2**32 - 1.
         debug_assert!(mantissa <= u32::MAX as u64);
         write_digits_u32(bytes, mantissa as u32)
     }
@@ -1333,6 +1333,7 @@ impl DragonboxFloat for f64 {
 
     #[inline(always)]
     fn write_digits(bytes: &mut [u8], mantissa: u64) -> usize {
+        // NOTE: These digits are after shifting, so it can be 2**64 - 1.
         write_digits_u64(bytes, mantissa)
     }
 

--- a/lexical-write-integer/src/decimal.rs
+++ b/lexical-write-integer/src/decimal.rs
@@ -16,7 +16,7 @@
 use lexical_util::format::{RADIX, RADIX_SHIFT, STANDARD};
 use lexical_util::num::UnsignedInteger;
 
-use crate::algorithm::{algorithm, algorithm_u128};
+use crate::algorithm::algorithm_u128;
 use crate::digit_count::fast_log2;
 use crate::jeaiii;
 use crate::table::DIGIT_TO_BASE10_SQUARED;
@@ -254,37 +254,21 @@ pub trait Decimal: DecimalCount {
 
 // Implement decimal for type.
 macro_rules! decimal_impl {
-    ($($t:ty)*) => ($(
+    ($($t:ty; $f:ident)*) => ($(
         impl Decimal for $t {
             #[inline(always)]
             fn decimal(self, buffer: &mut [u8]) -> usize {
-                algorithm(self, 10, &DIGIT_TO_BASE10_SQUARED, buffer)
+                jeaiii::$f(self, buffer)
             }
         }
     )*);
 }
 
-decimal_impl! { u64 }
-
-impl Decimal for u8 {
-    #[inline(always)]
-    fn decimal(self, buffer: &mut [u8]) -> usize {
-        jeaiii::from_u8(self, buffer)
-    }
-}
-
-impl Decimal for u16 {
-    #[inline(always)]
-    fn decimal(self, buffer: &mut [u8]) -> usize {
-        jeaiii::from_u16(self, buffer)
-    }
-}
-
-impl Decimal for u32 {
-    #[inline(always)]
-    fn decimal(self, buffer: &mut [u8]) -> usize {
-        jeaiii::from_u32(self, buffer)
-    }
+decimal_impl! {
+    u8; from_u8
+    u16; from_u16
+    u32; from_u32
+    u64; from_u64
 }
 
 impl Decimal for u128 {

--- a/lexical-write-integer/src/jeaiii.rs
+++ b/lexical-write-integer/src/jeaiii.rs
@@ -66,6 +66,23 @@ macro_rules! write_n {
         $buffer[index + 1] = i!(DIGIT_TO_BASE10_SQUARED[r + 1]);
         index + 2
     }};
+
+    // Identical to `@2` except it's writing from the end, not front.
+    // This is for our Alexandrescu-popularized algorithm.
+    (@2sub $buffer:ident, $index:ident, $r:expr) => {{
+        $index -= 2;
+        _ = write_n!(@2 $buffer, $index, $r);
+    }};
+
+    // This writes 4 digits, using 2sub twice after getting the high and low.
+    (@4sub $buffer:ident, $index:ident, $value:ident) => {{
+        let r = $value % 10000;
+        $value /= 10000;
+        let r1 = 2 * (r / 100);
+        let r2 = 2 * (r % 100);
+        write_n!(@2sub $buffer, $index, r2);
+        write_n!(@2sub $buffer, $index, r1);
+    }};
 }
 
 // Print the next 2 digits, using `next2`.
@@ -159,6 +176,35 @@ macro_rules! write_digits {
         _ = write_n!(@2 $buffer, 6, next2(&mut y) * 2);
         write_n!(@2 $buffer, 8, next2(&mut y) * 2)
     }};
+
+    (@10u64 $buffer:ident, $n:ident) => {{
+        // Unfortunately, there is no good way without using 128 bits,
+        // since the smallest interval overflows a 64-bit integer at
+        // ~>= 5.5e9. This requires the value to be in `[1e9, 1e10)`,
+        // since there's no lower bound for the calculation and so it
+        // will not work with smaller values.
+        // D = 32, k = 8, L = 28
+        // `11529215047 = ceil(2^60 / 10^8)`
+        let prod = ($n as u128) * 11529215047u128;
+        let mut y = (prod >> 28) as u64;
+        _ = write_n!(@2 $buffer, 0, (y >> 32) * 2);
+        _ = write_n!(@2 $buffer, 2, next2(&mut y) * 2);
+        _ = write_n!(@2 $buffer, 4, next2(&mut y) * 2);
+        _ = write_n!(@2 $buffer, 6, next2(&mut y) * 2);
+        write_n!(@2 $buffer, 8, next2(&mut y) * 2)
+    }};
+
+    (@10alex $buffer:ident, $n:ident, $offset:ident) => {{
+        // This always writes 10 digits for any value `[0, 1e10)`,
+        // but it uses a slower algorithm to do so. Since we don't
+        // have to worry about
+        let mut value = $n;
+        let mut index = 10 + $offset;
+        write_n!(@4sub $buffer, index, value);
+        write_n!(@4sub $buffer, index, value);
+        write_n!(@2sub $buffer, index, value * 2);
+        10 + $offset
+    }};
 }
 
 /// Optimized jeaiii algorithm for u8.
@@ -225,8 +271,51 @@ pub fn from_u32(n: u32, buffer: &mut [u8]) -> usize {
     }
 }
 
+/// Optimized jeaiii algorithm for u64.
+#[inline(always)]
+#[allow(clippy::collapsible_else_if)] // reason = "branching is fine-tuned for performance"
+pub fn from_u64(n: u64, buffer: &mut [u8]) -> usize {
+    // NOTE: Like before, this optimizes better for large and small
+    // values if there's a flat comparison with larger values first.
+    const FACTOR: u64 = 100_0000_0000;
+    let buffer = &mut buffer[..20];
+    if n < 1_0000 {
+        // 1 to 4 digits
+        if n >= 100 {
+            write_digits!(@3-4 buffer, n)
+        } else if n >= 10 {
+            write_digits!(@2 buffer, n)
+        } else {
+            write_digits!(@1 buffer, n)
+        }
+    } else if n < 100_0000_0000 {
+        // 5 to 10 digits
+        if n >= 10_0000_0000 {
+            // NOTE: We DO NOT know if this is >= u32::MAX,
+            // and the `write_digits!(@10)` is only accurate
+            // if `n <= 5.5e9`, which we cannot guarantee.
+            write_digits!(@10u64 buffer, n)
+        } else if n >= 1_0000_0000 {
+            write_digits!(@9 buffer, n)
+        } else if n >= 100_0000 {
+            write_digits!(@7-8 buffer, n)
+        } else {
+            write_digits!(@5-6 buffer, n)
+        }
+    } else {
+        // 11-20 digits, can do in 2 steps
+        // NOTE: `hi` has to be in [0, 2^31], while `lo` is in `[0, 10^11)`
+        // So, we can use our `from_u64_small` for hi. For our `lo`, we always
+        // need to write 10 digits. However, the `jeaiii` algorithm is too
+        // slow, so we use a modified variant of our 2-digit unfolding for
+        // exactly 10 digits to read our values. We can optimize this in
+        // 2x 4 digits and 1x 2 digits.
+        let hi = (n / FACTOR) as u32;
+        let lo = n % FACTOR;
+        let offset = from_u32(hi, buffer);
+        write_digits!(@10alex buffer, lo, offset)
+    }
+}
+
 // TODO: Implement for:
-//  from_u64
 //  from_u128
-//  from_mant32 (23 bits)
-//  from_mant64 (53 bits)

--- a/lexical-write-integer/tests/api_tests.rs
+++ b/lexical-write-integer/tests/api_tests.rs
@@ -1301,6 +1301,11 @@ proptest! {
     }
 
     #[test]
+    fn jeaiii_magic_10u64_proptest(i in 10_0000_0000..100_0000_0000u64) {
+        prop_assert_eq!(i, roundtrip(i));
+    }
+
+    #[test]
     #[cfg(feature = "radix")]
     fn u8_proptest_radix(i in u8::MIN..u8::MAX, radix in 2u32..=36) {
         prop_assert_eq!(i, roundtrip_radix(i, radix));

--- a/lexical-write-integer/tests/api_tests.rs
+++ b/lexical-write-integer/tests/api_tests.rs
@@ -1444,12 +1444,6 @@ fn u64_buffer_test() {
 }
 
 #[test]
-fn u64_buffer_no_panic_test() {
-    let mut buffer = [b'\x00'; 6];
-    12345i64.to_lexical(&mut buffer);
-}
-
-#[test]
 #[should_panic]
 fn u128_buffer_test() {
     let mut buffer = [b'\x00'; 8];


### PR DESCRIPTION
This adds in the jeaiii integer serialization optimizations for u64 types, however, this has one handy addition: it uses the 2-digit unfolding for when `n >= 10^10`. This is because the 10-digit optimization described in [Faster Integer Serialization](https://jk-jeon.github.io/posts/2022/02/jeaiii-algorithm/) with `D = 32`, `k = 8`, and `L = 25` (magic of 1441151881) does not work for values ~5.5e9 and larger. This bound was calculated using [jeaiii_analysis.cpp](https://github.com/jk-jeon/idiv/blob/main/subproject/example/jeaiii_analysis.cpp).

A bound that accepts up to `10^10 - 1` will overflow a 64-bit integer, with `D = 32`, `k = 8`, and `L = 28` (magic of 11529215047), however, this will not work for values <10 digits. The solution was to use the 2-digit unfolding approach for the low 10 digits if the value was >= 11 digits, since we know the high digits must fit in a `u32`. Since we must write exactly 10 digits, this is quite simple:

```rust
const FACTOR: u64 = 100_0000_0000;
let buffer = &mut buffer[..20];
let hi = (n / FACTOR) as u32;
let lo = n % FACTOR;
let offset = jeaiii_u32(hi, buffer);

// now write using 2-digit unfolding
let mut index = offset + 10;
let mut value = lo;
for _ in 0..2 {
    let r = value % 10000;
    value /= 10000;
    let r1 = 2 * (r / 100);
    let r2 = 2 * (r % 100);
    // ... process r1 and r2
}
// ... process 2 * value
```

Related to #163.