### PR TITLE
Add tests for formatting numeric limits

### DIFF
--- a/lexical-core/tests/api_tests.rs
+++ b/lexical-core/tests/api_tests.rs
@@ -53,3 +53,41 @@ fn string_to_float_test() {
         Ok((12345.0f32, 7))
     );
 }
+
+/// Test that converting the specified value into a buffer of FORMATTED_SIZE
+/// yields the expected string
+macro_rules! test_format {
+    ($t:ty, $value:expr, $expected:expr) => {{
+        use lexical_core::FormattedSize;
+        let mut buffer = [b'0'; <$t>::FORMATTED_SIZE];
+        let formatted = lexical_core::write($value, &mut buffer);
+        assert_eq!(
+            formatted,
+            $expected.as_bytes(),
+            "formatted: {}, expected: {}",
+            String::from_utf8_lossy(formatted),
+            $expected
+        );
+    }};
+}
+
+#[test]
+#[cfg(feature = "write-integers")]
+fn numeric_limit_string_tests() {
+    test_format!(u8, u8::MIN, "0");
+    test_format!(u8, u8::MAX, "255");
+    test_format!(u16, u16::MIN, "0");
+    test_format!(u16, u16::MAX, "65535");
+    test_format!(u32, u32::MIN, "0");
+    test_format!(u32, u32::MAX, "4294967295");
+    test_format!(u64, u64::MIN, "0");
+    test_format!(u64, u64::MAX, "18446744073709551615");
+    test_format!(i8, i8::MIN, "-128");
+    test_format!(i8, i8::MAX, "127");
+    test_format!(i16, i16::MIN, "-32768");
+    test_format!(i16, i16::MAX, "32767");
+    test_format!(i32, i32::MIN, "-2147483648");
+    test_format!(i32, i32::MAX, "2147483647");
+    test_format!(i64, i64::MIN, "-9223372036854775808");
+    test_format!(i64, i64::MAX, "9223372036854775807");
+}


### PR DESCRIPTION
Thank you @Alexhuszagh  for fixing https://github.com/Alexhuszagh/rust-lexical/issues/191 so quickly

# Rationale
While reviewing the fix, I figured it might be helpful to add some more test coverage (selfishly, so it is less likely a regression is introduced in the code we rely on downstream so much)

# Changes
Add a regression test for https://github.com/Alexhuszagh/rust-lexical/issues/191


I verified that when I ran prior to the fix for https://github.com/Alexhuszagh/rust-lexical/issues/191 this test fails

```
/Users/andrewlamb/.cargo/bin/cargo test --color=always --test api_tests --profile test --no-fail-fast --config env.RUSTC_BOOTSTRAP=\"1\" --manifest-path /Users/andrewlamb/Software/rust-lexical/lexical-core/Cargo.toml -- --format=json -Z unstable-options --show-output
Testing started at 6:54 AM ...
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running tests/api_tests.rs (target/debug/deps/api_tests-efef60155453cf76)

range end index 20 out of range for slice of length 19
thread 'numeric_limit_string_tests' panicked at /Users/andrewlamb/Software/rust-lexical/lexical-write-integer/src/jeaiii.rs:304:29:
range end index 20 out of range for slice of length 19
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/panicking.rs:74:14
   2: core::slice::index::slice_end_index_len_fail_rt
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/slice/index.rs:64:5
   3: core::slice::index::slice_end_index_len_fail
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/slice/index.rs:58:5
   4: <core::ops::range::Range<usize> as core::slice::index::SliceIndex<[T]>>::index_mut
             at /Users/andrewlamb/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/slice/index.rs:477:13
   5: <core::ops::range::RangeTo<usize> as core::slice::index::SliceIndex<[T]>>::index_mut
             at /Users/andrewlamb/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/slice/index.rs:555:9
   6: core::slice::index::<impl core::ops::index::IndexMut<I> for [T]>::index_mut
             at /Users/andrewlamb/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/slice/index.rs:27:9
   7: lexical_write_integer::jeaiii::from_u64
             at /Users/andrewlamb/Software/rust-lexical/lexical-write-integer/src/jeaiii.rs:304:29
   8: <u64 as lexical_write_integer::decimal::Decimal>::decimal
             at /Users/andrewlamb/Software/rust-lexical/lexical-write-integer/src/decimal.rs:258:17
   9: lexical_write_integer::write::WriteInteger::write_integer
             at /Users/andrewlamb/Software/rust-lexical/lexical-write-integer/src/write.rs:79:9
  10: lexical_write_integer::write::WriteInteger::write_mantissa
             at /Users/andrewlamb/Software/rust-lexical/lexical-write-integer/src/write.rs:22:13
  11: lexical_write_integer::api::signed
             at /Users/andrewlamb/Software/rust-lexical/lexical-write-integer/src/api.rs:58:9
  12: <i64 as lexical_write_integer::api::ToLexical>::to_lexical
             at /Users/andrewlamb/Software/rust-lexical/lexical-write-integer/src/api.rs:116:27
  13: <i64 as lexical_core::ToLexical>::to_lexical
             at ./src/lib.rs:520:17
  14: lexical_core::write
             at ./src/lib.rs:609:5
  15: api_tests::numeric_limit_string_tests
             at ./tests/api_tests.rs:63:25
  16: api_tests::numeric_limit_string_tests::{{closure}}
             at ./tests/api_tests.rs:76:32
  17: core::ops::function::FnOnce::call_once
             at /Users/andrewlamb/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  18: core::ops::function::FnOnce::call_once
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: test failed, to rerun pass `--test api_tests`
error: 1 target failed:
    `--test api_tests`

Process finished with exit code 101
```

