### PR TITLE
Fixes the comparison chain for NaN and equality in half floats.

### DIFF
--- a/lexical-util/Cargo.toml
+++ b/lexical-util/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "lexical-util"
 readme = "README.md"
 repository = "https://github.com/Alexhuszagh/rust-lexical"
-version = "1.0.5"
+version = "1.0.6"
 rust-version = "1.63.0"
 exclude = [
     "assets/*",

--- a/lexical-util/src/bf16.rs
+++ b/lexical-util/src/bf16.rs
@@ -168,7 +168,9 @@ impl bf16 {
     #[must_use]
     #[inline(always)]
     pub const fn is_nan(self) -> bool {
-        !eq(self, self)
+        let bits = self.to_bits();
+        let is_special = bits & Self::EXPONENT_MASK == Self::EXPONENT_MASK;
+        is_special && (bits & Self::MANTISSA_MASK) != 0
     }
 
     /// Computes the absolute value of `self`.

--- a/lexical-util/src/f16.rs
+++ b/lexical-util/src/f16.rs
@@ -168,7 +168,9 @@ impl f16 {
     #[must_use]
     #[inline(always)]
     pub const fn is_nan(self) -> bool {
-        !eq(self, self)
+        let bits = self.to_bits();
+        let is_special = bits & Self::EXPONENT_MASK == Self::EXPONENT_MASK;
+        is_special && (bits & Self::MANTISSA_MASK) != 0
     }
 
     /// Computes the absolute value of `self`.

--- a/lexical-write-float/tests/api_tests.rs
+++ b/lexical-write-float/tests/api_tests.rs
@@ -142,8 +142,6 @@ proptest! {
     #[test]
     #[cfg(feature = "f16")]
     fn f16_proptest(bits in u16::MIN..u16::MAX) {
-        use lexical_util::num::Float;
-
         let mut buffer = [b'\x00'; BUFFER_SIZE];
         let f = f16::from_bits(bits);
         let actual = unsafe { std::str::from_utf8_unchecked(f.to_lexical(&mut buffer)) };
@@ -158,8 +156,6 @@ proptest! {
     #[test]
     #[cfg(feature = "f16")]
     fn bf16_proptest(bits in u16::MIN..u16::MAX) {
-        use lexical_util::num::Float;
-
         let mut buffer = [b'\x00'; BUFFER_SIZE];
         let f = bf16::from_bits(bits);
         let actual = unsafe { std::str::from_utf8_unchecked(f.to_lexical(&mut buffer)) };


### PR DESCRIPTION
This fixes the infinite recursion in `f16` and `bf16` when checking float equality or `is_nan`. This is patched by fixing the `is_nan` comparison.

Closes #196